### PR TITLE
feature: create category area store domains (#4)

### DIFF
--- a/src/main/java/com/example/delivery/area/domain/entity/AreaEntity.java
+++ b/src/main/java/com/example/delivery/area/domain/entity/AreaEntity.java
@@ -1,0 +1,55 @@
+package com.example.delivery.area.domain.entity;
+
+import com.example.delivery.global.infrastructure.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_area")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AreaEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "area_id",  nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(length = 100, nullable = false, unique = true)
+    private String name;
+
+    @Column(length = 50, nullable = false)
+    private String city;
+
+    @Column(length = 50, nullable = false)
+    private String district;
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    /**
+     * name: 지역명 (예: 광화문)
+     * city: 시/도
+     * district: 구/군
+     * isActive: 운영 활성화 여부 (default = true)
+     */
+    @Builder
+    public AreaEntity(String name, String city, String district) {
+        this.name = name;
+        this.city = city;
+        this.district = district;
+        this.isActive = true;
+    }
+
+    /**
+     * 활성화 여부 변경 메서드
+     */
+    public void toggleActive() {
+        this.isActive = !this.isActive;
+    }
+}

--- a/src/main/java/com/example/delivery/area/domain/repository/AreaRepository.java
+++ b/src/main/java/com/example/delivery/area/domain/repository/AreaRepository.java
@@ -1,0 +1,7 @@
+package com.example.delivery.area.domain.repository;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AreaRepository extends JpaRepository<AreaEntity, Long> {
+}

--- a/src/main/java/com/example/delivery/area/domain/repository/AreaRepository.java
+++ b/src/main/java/com/example/delivery/area/domain/repository/AreaRepository.java
@@ -1,7 +1,4 @@
 package com.example.delivery.area.domain.repository;
 
-import com.example.delivery.area.domain.entity.AreaEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AreaRepository extends JpaRepository<AreaEntity, Long> {
+public interface AreaRepository {
 }

--- a/src/main/java/com/example/delivery/area/infrastructure/repository/AreaJpaRepository.java
+++ b/src/main/java/com/example/delivery/area/infrastructure/repository/AreaJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.delivery.area.infrastructure.repository;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AreaJpaRepository extends JpaRepository<AreaEntity, Long> {
+}

--- a/src/main/java/com/example/delivery/category/domain/entity/CategoryEntity.java
+++ b/src/main/java/com/example/delivery/category/domain/entity/CategoryEntity.java
@@ -1,0 +1,34 @@
+package com.example.delivery.category.domain.entity;
+
+import com.example.delivery.global.infrastructure.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "category_id",  nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(length = 50, nullable = false, unique = true)
+    private String name;
+
+    @Builder
+    public CategoryEntity(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 카테고리 이름 수정 메서드
+     */
+    public void updateName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/delivery/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/example/delivery/category/domain/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.delivery.category.domain.repository;
+
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+}

--- a/src/main/java/com/example/delivery/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/example/delivery/category/domain/repository/CategoryRepository.java
@@ -1,7 +1,4 @@
 package com.example.delivery.category.domain.repository;
 
-import com.example.delivery.category.domain.entity.CategoryEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+public interface CategoryRepository {
 }

--- a/src/main/java/com/example/delivery/category/infrastructure/repository/CategoryJpaRepository.java
+++ b/src/main/java/com/example/delivery/category/infrastructure/repository/CategoryJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.delivery.category.infrastructure.repository;
+
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryJpaRepository extends JpaRepository<CategoryEntity, Long> {
+}

--- a/src/main/java/com/example/delivery/store/domain/entity/StoreEntity.java
+++ b/src/main/java/com/example/delivery/store/domain/entity/StoreEntity.java
@@ -1,0 +1,80 @@
+package com.example.delivery.store.domain.entity;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.global.infrastructure.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_store")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "store_id",  nullable = false, updatable = false)
+    private UUID id;
+
+    /**
+     * User 도메인과는 ID만 참조하도록 함
+     */
+    @Column(length = 10, nullable = false)
+    private Long ownerId;
+
+    /**
+     * Category 및 Area 도메인은 Store에서만 사용하므로 엔티티를 참조함
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CategoryEntity category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "area_id", nullable = false)
+    private AreaEntity area;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(length = 255, nullable = false)
+    private String address;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(precision = 2, scale = 1, nullable = false)
+    private BigDecimal averageRating;
+
+    @Column(nullable = false)
+    private boolean isHidden;
+
+    @Builder
+    public StoreEntity(Long ownerId, CategoryEntity category, AreaEntity area, String name, String address, String phone) {
+        this.ownerId = ownerId;
+        this.category = category;
+        this.area = area;
+        this.name = name;
+        this.address = address;
+        this.phone = phone;
+        this.averageRating = BigDecimal.ZERO;
+        this.isHidden = false;
+    }
+
+    /**
+     * 연관관계 메서드
+     */
+    public void updateAverageRating(BigDecimal averageRating) {
+        this.averageRating = averageRating;
+    }
+
+    public void toggleHidden() {
+        this.isHidden = !this.isHidden;
+    }
+}

--- a/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.example.delivery.store.domain.repository;
+
+import com.example.delivery.store.domain.entity.StoreEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
+}

--- a/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
@@ -1,7 +1,4 @@
 package com.example.delivery.store.domain.repository;
 
-import com.example.delivery.store.domain.entity.StoreEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
+public interface StoreRepository {
 }

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.delivery.store.infrastructure.repository;
+
+import com.example.delivery.store.domain.entity.StoreEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreJpaRepository extends JpaRepository<StoreEntity, Long> {
+}


### PR DESCRIPTION
## 연관 이슈
- close #4 

## 작업 내용
- **Category** 엔티티 생성
- **Area** 엔티티 생성
- **Store** 엔티티 생성
- `domain/repository` 에 Category, Area, Store **일반 Repository** 생성
- `infrastructure/repository` 에 각 엔티티 **JPA Repository** 추가 생성

## 후속 작업
Merge 이후 각 도메인별로 CRUD 개발할 예정입니다.