### PR TITLE
Feature/2 setup menu domain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ repositories {
 }
 
 dependencies {
+    // Swagger (SpringDoc) 라이브러리 추가
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/example/delivery/ai/domain/entity/AiRequestLogEntity.java
+++ b/src/main/java/com/example/delivery/ai/domain/entity/AiRequestLogEntity.java
@@ -1,0 +1,44 @@
+package com.example.delivery.ai.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_ai_request_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiRequestLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    //인증/인가 구현 후 User 매핑 예정 (현재는 BaseEntity의 createdBy로 추적)
+    @Column(columnDefinition = "TEXT")
+    private String prompt;
+
+    @Column(columnDefinition = "TEXT")
+    private String responseText;
+
+    private UUID menuId;
+
+    @Column(nullable = false)
+    private Boolean isApplied = false;
+
+    @Builder
+    public AiRequestLogEntity(String prompt, String responseText){
+        this.prompt = prompt;
+        this.responseText = responseText;
+        this.isApplied = false;
+    }
+
+    public void assignToMenu(UUID menuId){
+        this.menuId = menuId;
+        this.isApplied = true;
+    }
+}

--- a/src/main/java/com/example/delivery/ai/domain/repository/AiRequestLogRepository.java
+++ b/src/main/java/com/example/delivery/ai/domain/repository/AiRequestLogRepository.java
@@ -1,0 +1,11 @@
+package com.example.delivery.ai.domain.repository;
+
+import com.example.delivery.ai.domain.entity.AiRequestLogEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AiRequestLogRepository {
+    AiRequestLogEntity save(AiRequestLogEntity aiLog);
+    Optional<AiRequestLogEntity> findById(UUID id);
+}

--- a/src/main/java/com/example/delivery/ai/infrastructure/repository/AiRequestLogJpaRepository.java
+++ b/src/main/java/com/example/delivery/ai/infrastructure/repository/AiRequestLogJpaRepository.java
@@ -1,0 +1,9 @@
+package com.example.delivery.ai.infrastructure.repository;
+
+import com.example.delivery.ai.domain.entity.AiRequestLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AiRequestLogJpaRepository extends JpaRepository<AiRequestLogEntity, UUID> {
+}

--- a/src/main/java/com/example/delivery/ai/infrastructure/repository/AiRequestLogRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/ai/infrastructure/repository/AiRequestLogRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.example.delivery.ai.infrastructure.repository;
+
+import com.example.delivery.ai.domain.entity.AiRequestLogEntity;
+import com.example.delivery.ai.domain.repository.AiRequestLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class AiRequestLogRepositoryImpl implements AiRequestLogRepository {
+
+    private final AiRequestLogJpaRepository aiRequestLogJpaRepository;
+
+    @Override
+    public AiRequestLogEntity save(AiRequestLogEntity aiLog){
+        return aiRequestLogJpaRepository.save(aiLog);
+    }
+
+    @Override
+    public Optional<AiRequestLogEntity> findById(UUID id){
+        return aiRequestLogJpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -20,6 +20,14 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
+    //Menu
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게룰 찾을 수 없습니다."),
+
+    //AI
+    AI_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "AI 요청 기록을 찾을 수 없습니다."),
+    AI_DESCRIPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 설명 생성에 실패했습니다."),
+
     //Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
     INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태를 변경할 수 없습니다."),

--- a/src/main/java/com/example/delivery/menu/application/service/MenuServiceV1.java
+++ b/src/main/java/com/example/delivery/menu/application/service/MenuServiceV1.java
@@ -1,0 +1,65 @@
+package com.example.delivery.menu.application.service;
+
+import com.example.delivery.ai.domain.entity.AiRequestLogEntity;
+import com.example.delivery.ai.domain.repository.AiRequestLogRepository;
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+import com.example.delivery.menu.domain.entity.MenuEntity;
+import com.example.delivery.menu.domain.repository.MenuRepository;
+import com.example.delivery.menu.presentation.dto.request.ReqCreateMenuDto;
+import com.example.delivery.menu.presentation.dto.response.ResMenuDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuServiceV1 {
+
+    private final MenuRepository menuRepository;
+
+    private final AiRequestLogRepository aiRequestLogRepository;
+
+    @Transactional
+    public ResMenuDto createMenu(UUID storeId, ReqCreateMenuDto reqDto) {
+
+        //메뉴 생성
+
+        //권한 검증 : Security 기능 완성되면 구현예정(현재 로그인한 유저가 이 storeId의 사장님이 맞는지 확인)
+
+        MenuEntity newMenu = MenuEntity.builder()
+                .storeId(storeId)
+                .name(reqDto.name())
+                .description(reqDto.description())
+                .price(reqDto.price())
+                .isHidden(reqDto.isHidden())
+                .aiDescription(reqDto.aiRequestId() != null) //AI ID가 넘어왔다면 AI가 작성한 것으로 간주
+                .build();
+
+        MenuEntity savedMenu = menuRepository.save(newMenu);
+
+        //AI 생성 요청이었다면, AI 로그 엔티티에 방금 생성된 메뉴의 ID(saveMenu.getId())를 매핑하고, isApplied = true 로 업데이트
+        if (reqDto.aiRequestId() != null){
+            AiRequestLogEntity aiLog = aiRequestLogRepository.findById(reqDto.aiRequestId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.AI_LOG_NOT_FOUND));
+
+            aiLog.assignToMenu(savedMenu.getId());
+        }
+
+        return ResMenuDto.from(savedMenu);
+    }
+
+    //손님용 메뉴 목록 조회
+    public List<ResMenuDto> getVisibleMenus(UUID storeId){
+        //삭제 안 됨 + 숨김 안 됨 조건으로 리스트를 가져옴
+        return menuRepository.findVisibleMenusByStoreId(storeId)
+                .stream()
+                .map(ResMenuDto::from)
+                .toList();
+    }
+
+}

--- a/src/main/java/com/example/delivery/menu/domain/entity/MenuEntity.java
+++ b/src/main/java/com/example/delivery/menu/domain/entity/MenuEntity.java
@@ -1,0 +1,82 @@
+package com.example.delivery.menu.domain.entity;
+
+import com.example.delivery.global.infrastructure.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_product", indexes = {
+        @Index(name = "idx_product_store", columnList = "storeId")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenuEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+
+    @Column(nullable = false)
+    private UUID storeId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private Boolean isHidden = false;
+
+    @Column(nullable = false)
+    private Boolean aiDescription = false;
+
+    private LocalDateTime deletedAt;
+    private String deletedBy;
+
+    @Builder
+    public MenuEntity(UUID storeId, String name, String description, Integer price, Boolean isHidden, Boolean aiDescription){
+        validatePrice(price);
+        this.storeId = storeId;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.isHidden = isHidden != null ? isHidden : false;
+        this.aiDescription = aiDescription != null ? aiDescription : false;
+    }
+
+    public void updateProduct(String name, String description, Integer price, Boolean aiDescription){
+        if(price != null) validatePrice(price);
+        if(name != null) this.name = name;
+        if(description != null) this.description = description;
+        if(price != null) this.price = price;
+        if(aiDescription != null) this.aiDescription = aiDescription;
+    }
+
+    public void updateVisibility(boolean isHidden){
+        this.isHidden = isHidden;
+    }
+
+    public void delete(String deletedBy){
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
+
+    private void validatePrice(Integer price){
+        //DB 명세가 CHECK >=0 이므로, 0보다 작으면 에러 발생
+        if(price != null && price <0){
+            throw new IllegalArgumentException("상품 가격은 0원 이상이어야 합니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/example/delivery/menu/domain/repository/MenuRepository.java
+++ b/src/main/java/com/example/delivery/menu/domain/repository/MenuRepository.java
@@ -1,0 +1,17 @@
+package com.example.delivery.menu.domain.repository;
+
+import com.example.delivery.menu.domain.entity.MenuEntity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MenuRepository {
+
+    MenuEntity save(MenuEntity menu);
+
+    Optional<MenuEntity> findById(UUID id);
+
+    //특정 가게의 삭제/숨김 처리 안 된 메뉴 목록 조회
+    List<MenuEntity> findVisibleMenusByStoreId(UUID storeId);
+}

--- a/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuJpaRepository.java
+++ b/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuJpaRepository.java
@@ -1,0 +1,12 @@
+package com.example.delivery.menu.infrastructure.repository;
+
+import com.example.delivery.menu.domain.entity.MenuEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MenuJpaRepository extends JpaRepository<MenuEntity, UUID> {
+
+    List<MenuEntity> findAllByStoreIdAndDeletedAtIsNullAndIsHiddenFalse(UUID storeId);
+}

--- a/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.example.delivery.menu.infrastructure.repository;
+
+import com.example.delivery.menu.domain.entity.MenuEntity;
+import com.example.delivery.menu.domain.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class MenuRepositoryImpl implements MenuRepository {
+
+    private final MenuJpaRepository menuJpaRepository;
+
+    @Override
+    public MenuEntity save(MenuEntity menu){
+        return menuJpaRepository.save(menu);
+    }
+
+    @Override
+    public Optional<MenuEntity> findById(UUID id){
+        return menuJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<MenuEntity> findVisibleMenusByStoreId(UUID storeId){
+        return menuJpaRepository.findAllByStoreIdAndDeletedAtIsNullAndIsHiddenFalse(storeId);
+
+    }
+}

--- a/src/main/java/com/example/delivery/menu/presentation/dto/request/ReqCreateMenuDto.java
+++ b/src/main/java/com/example/delivery/menu/presentation/dto/request/ReqCreateMenuDto.java
@@ -1,0 +1,31 @@
+package com.example.delivery.menu.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@Schema(description = "메뉴(상품) 등록 요청 DTO")
+public record ReqCreateMenuDto(
+
+        @Schema(description = "상품 이름", example = "오리지널 치킨")
+        @NotBlank(message = "상품 이름은 필수입니다.")
+        @Size(max = 20, message = "상품 이름은 최대 20자까지 가능합니다.")
+        String name,
+
+        @Schema(description = "상품 설명", example = "바삭바삭하고 풍미 가득한 오리지널 치킨")
+        @Size(max = 100, message = "상품 설명은 최대 100자까지 가능합니다.")
+        String description,
+
+        @Schema(description = "가격", example = "25000")
+        @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+        Integer price,
+
+        @Schema(description = "숨김 여부", example = "false")
+        Boolean isHidden,
+
+        @Schema(description = "AI 생성 시 발급받은 로그 ID(직접 입력 시 생략)", example = "123e4567-e89b-12d3-a456-426614174000")
+        UUID aiRequestId) {
+}

--- a/src/main/java/com/example/delivery/menu/presentation/dto/request/ReqUpdateMenuDto.java
+++ b/src/main/java/com/example/delivery/menu/presentation/dto/request/ReqUpdateMenuDto.java
@@ -1,0 +1,26 @@
+package com.example.delivery.menu.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@Schema(description = "메뉴(상품) 수정 DTO")
+public record ReqUpdateMenuDto(
+
+        @Schema(description = "변경할 상품 이름")
+        @Size(max = 20, message = "상품 이름은 최대 20자까지 가능합니다.")
+        String name,
+
+        @Schema(description = "변경할 상품 설명")
+        @Size(max = 100, message = "상품 설명은 최대 100자까지 가능합니다.")
+        String description,
+
+        @Schema(description = "변경할 가격")
+        @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+        Integer price,
+
+        @Schema(description = "AI를 이용해 설명을 다시 생헝한 경우의 로그 ID")
+        UUID aiRequestId) {
+}

--- a/src/main/java/com/example/delivery/menu/presentation/dto/response/ResMenuDto.java
+++ b/src/main/java/com/example/delivery/menu/presentation/dto/response/ResMenuDto.java
@@ -1,0 +1,31 @@
+package com.example.delivery.menu.presentation.dto.response;
+import com.example.delivery.menu.domain.entity.MenuEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "메뉴(상품) 응답 DTO")
+public record ResMenuDto(
+        UUID id,
+        UUID storeId,
+        String name,
+        String description,
+        Integer price,
+        Boolean isHidden,
+        Boolean aiDescription
+) {
+    public static ResMenuDto from(MenuEntity entity) {
+        return new ResMenuDto(
+                entity.getId(),
+                entity.getStoreId(),
+                entity.getName(),
+                entity.getDescription(),
+                entity.getPrice(),
+                entity.getIsHidden(),
+                entity.getAiDescription()
+        );
+    }
+}
+
+
+


### PR DESCRIPTION
##  작업 내용

**AI 도메인 (AI Request Log)**
* AI 설명 생성 이력 추적을 위한 `AiRequestLogEntity` 설계
* DIP 패턴을 적용한 3계층 Repository 구조 세팅

**Menu 도메인 (Menu)**
* `MenuEntity` 및 생성/조회용 DTO 설계 (Swagger `@Schema` 적용)
* DIP 패턴을 적용한 Menu Repository 계층 세팅
* 메뉴 생성 및 노출 가능한 메뉴 목록 조회 Service 비즈니스 로직 구현

---

##  리뷰어 참고 사항 (To Reviewers)

**공통 환경 설정이 추가되었습니다.**
  1. **Swagger 의존성 추가**: 최신 코드 Pull 받으신 후 꼭 **Gradle Refresh**를 눌러주세요!
  2. **에러 코드 추가**: `ErrorCode.java`에 Menu 및 AI 전용 에러 코드(`MENU_NOT_FOUND` 등)를 새로 추가했습니다. 