### PR TITLE
feature: 본인 계정 API 보강 및 문서화 (#30)

### DIFF
--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     CANNOT_DELETE_SELF(HttpStatus.BAD_REQUEST, "자기 자신은 삭제할 수 없습니다."),
+    CURRENT_PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "비밀번호 변경 시 현재 비밀번호가 필요합니다."),
+    INVALID_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다."),
 
     //Menu
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),

--- a/src/main/java/com/example/delivery/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/delivery/global/common/response/ApiResponse.java
@@ -1,15 +1,17 @@
 package com.example.delivery.global.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "공통 응답 래퍼")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(
-        int status,
-        String message,
-        T data,
-        List<FieldError> errors
+        @Schema(description = "HTTP 상태 코드", example = "200") int status,
+        @Schema(description = "응답 메시지 또는 오류 코드", example = "SUCCESS") String message,
+        @Schema(description = "실제 응답 데이터 (성공 시)") T data,
+        @Schema(description = "필드 단위 검증 오류 목록 (400 VALIDATION_ERROR 일 때)") List<FieldError> errors
 ) {
 
     public static <T> ApiResponse<T> ok(T data) {
@@ -28,7 +30,10 @@ public record ApiResponse<T>(
         return new ApiResponse<>(400, message, null, errors);
     }
 
-    public record FieldError(String field, String message) {
+    @Schema(description = "필드 단위 검증 오류")
+    public record FieldError(
+            @Schema(description = "오류가 발생한 필드명", example = "password") String field,
+            @Schema(description = "필드별 오류 메시지", example = "size must be between 8 and 15") String message) {
 
     }
 }

--- a/src/main/java/com/example/delivery/global/common/response/PageResponse.java
+++ b/src/main/java/com/example/delivery/global/common/response/PageResponse.java
@@ -1,17 +1,19 @@
 package com.example.delivery.global.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
+@Schema(description = "페이지네이션 응답")
 public record PageResponse<T>(
-        List<T> content,
-        int page,
-        int size,
-        long totalElements,
-        int totalPages,
-        String sort
+        @Schema(description = "현재 페이지 콘텐츠") List<T> content,
+        @Schema(description = "0-based 페이지 인덱스", example = "0") int page,
+        @Schema(description = "페이지 크기 (10/30/50 중 하나)", example = "10") int size,
+        @Schema(description = "전체 요소 수", example = "42") long totalElements,
+        @Schema(description = "전체 페이지 수", example = "5") int totalPages,
+        @Schema(description = "정렬 기준", example = "createdAt, DESC") String sort
 ) {
     public static <T> PageResponse<T> from(Page<T> page) {
         return new PageResponse<>(

--- a/src/main/java/com/example/delivery/global/infrastructure/config/OpenApiConfig.java
+++ b/src/main/java/com/example/delivery/global/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,50 @@
+package com.example.delivery.global.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_SCHEME = "bearerAuth";
+
+    private static final String API_DESCRIPTION = """
+            배달 서비스 API 문서.
+
+            ## 인증
+            1. `POST /api/v1/auth/signup` 또는 `POST /api/v1/auth/login`으로 JWT 발급.
+            2. 페이지 상단 **Authorize** 버튼 → `bearerAuth` 입력란에 토큰만 붙여넣기 (Bearer 접두사 불필요).
+            3. 이후 보호 엔드포인트는 자동으로 `Authorization: Bearer <token>` 헤더가 부착.
+
+            ## 공통 규약
+            - 모든 응답은 `ApiResponse<T>` 래퍼 (`status`, `message`, `data`, `errors`) 포맷.
+            - 권한 재검증: 매 요청 JWT payload role ↔ DB role 비교, 불일치 시 403.
+            """;
+
+    @Bean
+    public OpenAPI deliveryOpenAPI() {
+        SecurityScheme bearer = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .description("`POST /api/v1/auth/login` 응답의 accessToken을 그대로 입력.");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Delivery API")
+                        .description(API_DESCRIPTION)
+                        .version("v1"))
+                .servers(List.of(new Server().url("http://localhost:8080").description("Local")))
+                .components(new Components().addSecuritySchemes(BEARER_SCHEME, bearer))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME));
+    }
+}

--- a/src/main/java/com/example/delivery/global/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/example/delivery/global/infrastructure/config/SecurityConfig.java
@@ -36,7 +36,11 @@ public class SecurityConfig {
             "/actuator/info",
             "/error",
             "/api/v1/test/users",
-            "/api/v1/auth/**"
+            "/api/v1/auth/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs",
+            "/v3/api-docs/**"
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/example/delivery/user/application/service/UserService.java
+++ b/src/main/java/com/example/delivery/user/application/service/UserService.java
@@ -31,9 +31,25 @@ public class UserService {
     @Transactional
     public ResUserDto update(String username, ReqUpdateUser req, LoginUser me) {
         UserEntity user = findUserOrThrow(username);
+        verifyCurrentPasswordIfChanging(user, req, me);
         user.update(me, toUpdateCommand(req, username));
 
         return ResUserDto.from(user);
+    }
+
+    private void verifyCurrentPasswordIfChanging(UserEntity user, ReqUpdateUser req, LoginUser me) {
+        if (req.password() == null) {
+            return;
+        }
+        if (!me.isSelf(user.getUsername().value())) {
+            return;
+        }
+        if (req.currentPassword() == null || req.currentPassword().isBlank()) {
+            throw new BusinessException(ErrorCode.CURRENT_PASSWORD_REQUIRED);
+        }
+        if (!passwordEncoder.matches(req.currentPassword(), user.getPasswordHash())) {
+            throw new BusinessException(ErrorCode.INVALID_CURRENT_PASSWORD);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/example/delivery/user/presentation/controller/AuthController.java
+++ b/src/main/java/com/example/delivery/user/presentation/controller/AuthController.java
@@ -6,6 +6,10 @@ import com.example.delivery.user.presentation.dto.request.ReqLogin;
 import com.example.delivery.user.presentation.dto.request.ReqSignup;
 import com.example.delivery.user.presentation.dto.response.ResLogin;
 import com.example.delivery.user.presentation.dto.response.ResSignup;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,19 +19,87 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 인증 API 컨트롤러.
+ *
+ * - 회원가입(signup), 로그인(login) 두 가지 진입점을 제공한다.
+ * - 두 엔드포인트 모두 비인증 경로이며, SecurityConfig 의 PUBLIC_PATHS 에 등록되어 있다.
+ * - 클래스 레벨 {@code @SecurityRequirements}(empty)로 Swagger UI 의 전역 bearerAuth 요구를 해제한다.
+ * - 발급된 JWT(HS256)는 이후 모든 보호 엔드포인트에서 {@code Authorization: Bearer ...} 헤더로 전달한다.
+ */
+@Tag(name = "Auth", description = "회원가입/로그인")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@SecurityRequirements
 public class AuthController {
 
     private final AuthService authService;
 
+    /**
+     * 회원가입 — POST /api/v1/auth/signup
+     *
+     * 1. ReqSignup 의 물리 검증(NotBlank/Size)을 통과하면 AuthService.signup 으로 위임.
+     * 2. username/password/email 도메인 검증 → username·email 중복 확인 → BCrypt 해시 저장.
+     * 3. MANAGER/MASTER 는 이 API 로 가입할 수 없고, 추후 MASTER 가 PATCH /{username}/role 로 승격시킨다.
+     */
+    @Operation(
+            summary = "회원가입",
+            description = """
+                    CUSTOMER 또는 OWNER 권한으로 신규 유저를 등록한다.
+
+                    **검증 순서**
+                    1. `ReqSignup` 의 물리 검증 (NotBlank, Size).
+                    2. `Username`/`Email`/`Password` 도메인 규칙(정규식·길이·복잡도).
+                    3. username/email 중복 확인 → 409.
+                    4. BCrypt 해시 저장 후 `{ username, nickname, email, role, createdAt }` 반환.
+
+                    **제약**
+                    - `role` 은 CUSTOMER 또는 OWNER 만 허용. MANAGER/MASTER 로 가입 시도 시 `SIGNUP_ROLE_NOT_ALLOWED`.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+                    description = "VALIDATION_ERROR / SIGNUP_ROLE_NOT_ALLOWED / INVALID_USERNAME / INVALID_EMAIL / INVALID_PASSWORD"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409",
+                    description = "DUPLICATE_USERNAME / DUPLICATE_EMAIL")
+    })
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ResSignup> signup(@Valid @RequestBody ReqSignup req) {
         return ApiResponse.created(authService.signup(req));
     }
 
+    /**
+     * 로그인 — POST /api/v1/auth/login
+     *
+     * 1. findByUsername 으로 사용자 조회 (실패 시 401).
+     * 2. BCryptPasswordEncoder.matches 로 비밀번호 일치 검증 (실패 시 401).
+     * 3. JwtTokenProvider.issue 로 HS256 JWT 발급.
+     * 4. 응답: { accessToken, username, role }.
+     */
+    @Operation(
+            summary = "로그인",
+            description = """
+                    username/password 를 검증하고 JWT(HS256) 를 발급한다.
+
+                    **흐름**
+                    1. `findByUsername` → 없음이면 401 UNAUTHORIZED.
+                    2. `passwordEncoder.matches` → 불일치면 401 UNAUTHORIZED.
+                    3. `JwtTokenProvider.issue` 로 accessToken 생성 후 반환.
+
+                    **사용법**
+                    - 응답의 `accessToken` 을 복사해서 Swagger UI 상단 "Authorize" 버튼 → `bearerAuth` 입력란에 붙여넣으면 이후 요청이 자동으로 인증 헤더를 단다.
+                    - 직접 호출 시에는 `Authorization: Bearer <token>` 헤더로 보낸다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "JWT 발급"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "VALIDATION_ERROR"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    description = "UNAUTHORIZED — 사용자 없음 또는 비밀번호 불일치")
+    })
     @PostMapping("/login")
     public ApiResponse<ResLogin> login(@Valid @RequestBody ReqLogin req) {
         return ApiResponse.ok(authService.login(req));

--- a/src/main/java/com/example/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/example/delivery/user/presentation/controller/UserControllerV1.java
@@ -42,6 +42,12 @@ public class UserControllerV1 {
         return ApiResponse.ok(userService.search(keyword, role, pageable, LoginUser.from(me)));
     }
 
+    @GetMapping("/me")
+    public ApiResponse<ResUserDto> getMe(@AuthenticationPrincipal UserPrincipal me) {
+        LoginUser actor = LoginUser.from(me);
+        return ApiResponse.ok(userService.getOne(actor.username(), actor));
+    }
+
     @GetMapping("/{username}")
     public ApiResponse<ResUserDto> getOne(@PathVariable String username,
             @AuthenticationPrincipal UserPrincipal me) {

--- a/src/main/java/com/example/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/example/delivery/user/presentation/controller/UserControllerV1.java
@@ -9,6 +9,10 @@ import com.example.delivery.user.domain.entity.UserRole;
 import com.example.delivery.user.presentation.dto.request.ReqChangeRole;
 import com.example.delivery.user.presentation.dto.request.ReqUpdateUser;
 import com.example.delivery.user.presentation.dto.response.ResUserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +30,19 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 사용자 API 컨트롤러.
+ *
+ * - 본인/MANAGER/MASTER 권한 축으로 CRUD 를 분기한다.
+ *   · 본인만 가능: password 변경(currentPassword 동반 필수).
+ *   · 본인/MANAGER/MASTER: 조회/수정(password 제외).
+ *   · MANAGER/MASTER: 목록, Soft Delete.
+ *   · MASTER 전용: 권한 변경(`PATCH /{username}/role`), 대상이 privileged(MANAGER/MASTER)인 CUD.
+ * - Privileged 예외 규칙: 대상 role 이 MANAGER/MASTER 인 경우 위 규칙에서 "본인 또는 MASTER" 만 허용.
+ * - 인증 파이프라인: JwtAuthenticationFilter 가 매 요청 DB role/soft-delete 재검증 후 SecurityContext 주입.
+ * - Swagger 기준: 클래스가 전역 bearerAuth 요구를 상속한다. AuthController 와 달리 해제하지 않는다.
+ */
+@Tag(name = "User", description = "사용자 조회/수정/삭제/권한 변경")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -33,45 +50,217 @@ public class UserControllerV1 {
 
     private final UserService userService;
 
+    /**
+     * 사용자 목록 — GET /api/v1/users
+     *
+     * keyword(부분 일치) + role 필터를 조합해 페이지네이션으로 반환한다.
+     * MANAGER/MASTER 가 아닌 사용자가 호출하면 서비스 레이어에서 FORBIDDEN.
+     */
+    @Operation(
+            summary = "사용자 목록",
+            description = """
+                    keyword(username/nickname/email 부분 일치) + role 필터를 조합하여 사용자 목록을 조회한다.
+
+                    **권한**
+                    - MANAGER/MASTER 만 호출 가능. 그 외는 403 FORBIDDEN.
+
+                    **페이지네이션**
+                    - `page` 0-based, `size` 는 10/30/50 (그 외 값은 10 으로 보정 예정), `sort` 기본 `createdAt,DESC`.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "목록 반환"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "미인증/토큰 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "MANAGER/MASTER 아님")
+    })
     @GetMapping
     public ApiResponse<PageResponse<ResUserDto>> list(
+            @Parameter(description = "username/nickname/email 부분 일치 검색어", example = "alice")
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) UserRole role,
+            @Parameter(description = "권한 필터") @RequestParam(required = false) UserRole role,
+            @Parameter(description = "page=0-based, size={10|30|50}, sort=필드,ASC|DESC")
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-            @AuthenticationPrincipal UserPrincipal me) {
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal me) {
         return ApiResponse.ok(userService.search(keyword, role, pageable, LoginUser.from(me)));
     }
 
+    /**
+     * 본인 정보 조회 — GET /api/v1/users/me
+     *
+     * 인증된 JWT 소유자 본인의 정보를 반환한다.
+     * 내부적으로 {@code userService.getOne(self, self)} 로 위임하며,
+     * UserAccessPolicy 의 {@code isSelf} 분기에서 즉시 통과한다.
+     */
+    @Operation(
+            summary = "본인 정보 조회",
+            description = """
+                    현재 인증된 사용자의 정보를 반환한다. JWT 에서 username 을 추출해 내부적으로 상세 조회 서비스를 재사용한다.
+
+                    **사용 예**
+                    - 로그인 직후 프론트가 현재 사용자 프로필을 받을 때.
+                    - 클라이언트가 username 을 직접 알 필요가 없다.
+
+                    **인증 실패 동작**
+                    - 토큰 없음/만료 → 401.
+                    - 권한 변경으로 JWT.role ≠ DB.role → 403.
+                    - 계정이 Soft Delete 되었으면 → 401 (JwtAuthenticationFilter 에서 차단).
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "본인 정보"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "미인증/토큰 만료/Soft Delete된 계정")
+    })
     @GetMapping("/me")
-    public ApiResponse<ResUserDto> getMe(@AuthenticationPrincipal UserPrincipal me) {
+    public ApiResponse<ResUserDto> getMe(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal me) {
         LoginUser actor = LoginUser.from(me);
         return ApiResponse.ok(userService.getOne(actor.username(), actor));
     }
 
+    /**
+     * 사용자 상세 — GET /api/v1/users/{username}
+     *
+     * 본인, MANAGER, MASTER 가 조회 가능하다.
+     * 대상 role 이 privileged(MANAGER/MASTER)인 경우에는 본인 또는 MASTER 만 허용(MANAGER 끼리 상호 조회 불가).
+     */
+    @Operation(
+            summary = "사용자 상세",
+            description = """
+                    특정 사용자의 상세 정보를 반환한다.
+
+                    **권한**
+                    - 본인, MANAGER, MASTER.
+                    - 대상이 MANAGER/MASTER(privileged)인 경우 본인 또는 MASTER 만 조회 가능.
+
+                    **주의**
+                    - `is_public` 필드는 현재 조회 범위를 제어하지 않는다 (예약 필드, 데이터 명세 3.1 참조).
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상세 반환"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "미인증/토큰 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "본인/매니저/마스터 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+    })
     @GetMapping("/{username}")
-    public ApiResponse<ResUserDto> getOne(@PathVariable String username,
-            @AuthenticationPrincipal UserPrincipal me) {
+    public ApiResponse<ResUserDto> getOne(
+            @Parameter(description = "대상 사용자 아이디", example = "user01") @PathVariable String username,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal me) {
         return ApiResponse.ok(userService.getOne(username, LoginUser.from(me)));
     }
 
+    /**
+     * 사용자 정보 수정 — PATCH /api/v1/users/{username}
+     *
+     * 변경할 필드만 요청 바디에 담는 부분 업데이트.
+     * 비밀번호 변경 시에는 세션/토큰 탈취 대비로 현재 비밀번호(currentPassword) 동반 전송을 필수로 요구한다.
+     */
+    @Operation(
+            summary = "사용자 정보 수정",
+            description = """
+                    부분 업데이트 방식. 바디에 포함된 필드만 변경된다.
+
+                    **권한별 수정 가능 필드**
+                    - 본인: `nickname`, `email`, `password`, `isPublic`.
+                    - MANAGER/MASTER: `password` 제외 동일. (대상이 privileged 면 본인/MASTER 만 가능)
+
+                    **비밀번호 변경 규칙**
+                    - `password` 가 요청에 포함되면 `currentPassword` 필드도 필수.
+                    - 누락 → 400 `CURRENT_PASSWORD_REQUIRED`, 불일치 → 401 `INVALID_CURRENT_PASSWORD`.
+                    - 본인이 아닌 사용자가 `password` 를 시도하면 정책상 먼저 FORBIDDEN 으로 차단.
+
+                    **이메일 변경**
+                    - 다른 사용자가 사용 중이면 409 `DUPLICATE_EMAIL`.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+                    description = "VALIDATION_ERROR / CURRENT_PASSWORD_REQUIRED / INVALID_USERNAME / INVALID_EMAIL / INVALID_PASSWORD"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    description = "미인증 또는 INVALID_CURRENT_PASSWORD"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "대상 사용자 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "DUPLICATE_EMAIL")
+    })
     @PatchMapping("/{username}")
-    public ApiResponse<ResUserDto> update(@PathVariable String username,
+    public ApiResponse<ResUserDto> update(
+            @Parameter(description = "대상 사용자 아이디", example = "user01") @PathVariable String username,
             @Valid @RequestBody ReqUpdateUser req,
-            @AuthenticationPrincipal UserPrincipal me) {
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal me) {
         return ApiResponse.ok(userService.update(username, req, LoginUser.from(me)));
     }
 
+    /**
+     * 사용자 Soft Delete — DELETE /api/v1/users/{username}
+     *
+     * 물리 삭제가 아닌 {@code deleted_at = now(), deleted_by = actor} 로 논리 삭제.
+     * 이후 JPA 레벨 {@code @SQLRestriction("deleted_at IS NULL")} 으로 조회에서 자동 제외된다.
+     * 삭제된 계정으로 JWT 재사용 시 JwtAuthenticationFilter 가 401 UNAUTHORIZED 로 차단.
+     */
+    @Operation(
+            summary = "사용자 Soft Delete",
+            description = """
+                    사용자를 논리 삭제한다.
+
+                    **권한**
+                    - MANAGER/MASTER 만 가능.
+                    - 대상이 MANAGER/MASTER(privileged)인 경우 MASTER 만 가능.
+                    - 자기 자신은 삭제 불가 → 400 `CANNOT_DELETE_SELF`.
+
+                    **동작**
+                    - `deleted_at`, `deleted_by` 업데이트. 이후 해당 username 으로 로그인/조회 불가.
+                    - 기존 JWT 는 자동 무효화 (필터에서 soft-deleted 계정은 401 반환).
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "삭제 성공(본문 없음)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "CANNOT_DELETE_SELF"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "미인증/토큰 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+    })
     @DeleteMapping("/{username}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void softDelete(@PathVariable String username,
-            @AuthenticationPrincipal UserPrincipal me) {
+    public void softDelete(
+            @Parameter(description = "대상 사용자 아이디", example = "user01") @PathVariable String username,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal me) {
         userService.softDelete(username, LoginUser.from(me));
     }
 
+    /**
+     * 사용자 권한 변경 — PATCH /api/v1/users/{username}/role
+     *
+     * MASTER 만 사용 가능한 별도 엔드포인트. 본인의 role 은 변경할 수 없다.
+     * 권한 변경 후 다음 요청부터 JwtAuthenticationFilter 의 role 재검증에 의해
+     * 기존에 발급된 JWT 는 payload.role ≠ DB.role 로 403 ROLE_MISMATCH 처리된다.
+     */
+    @Operation(
+            summary = "사용자 권한 변경",
+            description = """
+                    사용자 권한을 변경한다.
+
+                    **권한**
+                    - MASTER 전용.
+                    - 본인 role 변경은 불가 → 403 FORBIDDEN.
+
+                    **효과**
+                    - 변경 후에도 대상의 기존 JWT 토큰 자체는 유효하지만, 매 요청 재검증에서 role 불일치로 403 ROLE_MISMATCH 반환.
+                    - 즉 실질적으로 기존 토큰은 무효화되고 대상은 재로그인 필요.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "권한 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "VALIDATION_ERROR"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "미인증/토큰 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "MASTER 아님 또는 본인 role 변경 시도"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "대상 사용자 없음")
+    })
     @PatchMapping("/{username}/role")
-    public ApiResponse<ResUserDto> changeRole(@PathVariable String username,
+    public ApiResponse<ResUserDto> changeRole(
+            @Parameter(description = "대상 사용자 아이디", example = "user01") @PathVariable String username,
             @Valid @RequestBody ReqChangeRole req,
-            @AuthenticationPrincipal UserPrincipal me) {
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal me) {
         return ApiResponse.ok(userService.changeRole(username, req, LoginUser.from(me)));
     }
 }

--- a/src/main/java/com/example/delivery/user/presentation/dto/request/ReqChangeRole.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/request/ReqChangeRole.java
@@ -1,8 +1,12 @@
 package com.example.delivery.user.presentation.dto.request;
 
 import com.example.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record ReqChangeRole(@NotNull UserRole role) {
+@Schema(description = "권한 변경 요청")
+public record ReqChangeRole(
+        @Schema(description = "새 권한", example = "MANAGER")
+        @NotNull UserRole role) {
 
 }

--- a/src/main/java/com/example/delivery/user/presentation/dto/request/ReqLogin.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/request/ReqLogin.java
@@ -1,9 +1,13 @@
 package com.example.delivery.user.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "로그인 요청")
 public record ReqLogin(
+        @Schema(description = "아이디", example = "user01")
         @NotBlank String username,
+        @Schema(description = "비밀번호", example = "Password1!")
         @NotBlank String password
 ) {
 

--- a/src/main/java/com/example/delivery/user/presentation/dto/request/ReqSignup.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/request/ReqSignup.java
@@ -1,15 +1,22 @@
 package com.example.delivery.user.presentation.dto.request;
 
 import com.example.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "회원가입 요청")
 public record ReqSignup(
+        @Schema(description = "아이디 (소문자/숫자 4~10자)", example = "user01")
         @NotBlank @Size(min = 4, max = 10) String username,
+        @Schema(description = "닉네임", example = "홍길동")
         @NotBlank @Size(max = 100) String nickname,
+        @Schema(description = "이메일", example = "user01@example.com")
         @NotBlank @Size(max = 255) String email,
+        @Schema(description = "비밀번호 (8~15자, 대/소/숫/특수 각 1자 이상)", example = "Password1!")
         @NotBlank @Size(min = 8, max = 15) String password,
+        @Schema(description = "권한 (CUSTOMER | OWNER)", example = "CUSTOMER")
         @NotNull UserRole role
 ) {
 

--- a/src/main/java/com/example/delivery/user/presentation/dto/request/ReqUpdateUser.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/request/ReqUpdateUser.java
@@ -6,6 +6,7 @@ public record ReqUpdateUser(
         @Size(max = 100) String nickname,
         @Size(max = 255) String email,
         @Size(min = 8, max = 15) String password,
+        @Size(min = 8, max = 15) String currentPassword,
         Boolean isPublic
 ) {
 

--- a/src/main/java/com/example/delivery/user/presentation/dto/request/ReqUpdateUser.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/request/ReqUpdateUser.java
@@ -1,12 +1,19 @@
 package com.example.delivery.user.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "사용자 정보 수정 요청 (변경할 필드만 전달)")
 public record ReqUpdateUser(
+        @Schema(description = "닉네임", example = "길동이")
         @Size(max = 100) String nickname,
+        @Schema(description = "이메일", example = "new@example.com")
         @Size(max = 255) String email,
+        @Schema(description = "새 비밀번호 (본인만 변경 가능)", example = "NewPass1!")
         @Size(min = 8, max = 15) String password,
+        @Schema(description = "현재 비밀번호 (password 변경 시 필수)", example = "OldPass1!")
         @Size(min = 8, max = 15) String currentPassword,
+        @Schema(description = "공개 여부 플래그", example = "true")
         Boolean isPublic
 ) {
 

--- a/src/main/java/com/example/delivery/user/presentation/dto/response/ResLogin.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/response/ResLogin.java
@@ -2,11 +2,13 @@ package com.example.delivery.user.presentation.dto.response;
 
 import com.example.delivery.user.domain.entity.UserEntity;
 import com.example.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "로그인 응답")
 public record ResLogin(
-        String accessToken,
-        String username,
-        UserRole role
+        @Schema(description = "JWT 액세스 토큰") String accessToken,
+        @Schema(description = "아이디", example = "user01") String username,
+        @Schema(description = "권한", example = "CUSTOMER") UserRole role
 ) {
 
     public static ResLogin of(String accessToken, UserEntity user) {

--- a/src/main/java/com/example/delivery/user/presentation/dto/response/ResSignup.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/response/ResSignup.java
@@ -2,14 +2,16 @@ package com.example.delivery.user.presentation.dto.response;
 
 import com.example.delivery.user.domain.entity.UserEntity;
 import com.example.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "회원가입 응답")
 public record ResSignup(
-        String username,
-        String nickname,
-        String email,
-        UserRole role,
-        LocalDateTime createdAt
+        @Schema(description = "아이디", example = "user01") String username,
+        @Schema(description = "닉네임", example = "홍길동") String nickname,
+        @Schema(description = "이메일", example = "user01@example.com") String email,
+        @Schema(description = "권한", example = "CUSTOMER") UserRole role,
+        @Schema(description = "가입 시각") LocalDateTime createdAt
 ) {
 
     public static ResSignup from(UserEntity user) {

--- a/src/main/java/com/example/delivery/user/presentation/dto/response/ResUserDto.java
+++ b/src/main/java/com/example/delivery/user/presentation/dto/response/ResUserDto.java
@@ -2,15 +2,17 @@ package com.example.delivery.user.presentation.dto.response;
 
 import com.example.delivery.user.domain.entity.UserEntity;
 import com.example.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "사용자 응답")
 public record ResUserDto(
-        String username,
-        String nickname,
-        String email,
-        UserRole role,
-        boolean isPublic,
-        LocalDateTime createdAt
+        @Schema(description = "아이디", example = "user01") String username,
+        @Schema(description = "닉네임", example = "홍길동") String nickname,
+        @Schema(description = "이메일", example = "user01@example.com") String email,
+        @Schema(description = "권한", example = "CUSTOMER") UserRole role,
+        @Schema(description = "공개 여부", example = "true") boolean isPublic,
+        @Schema(description = "가입 시각") LocalDateTime createdAt
 ) {
 
     public static ResUserDto from(UserEntity user) {

--- a/src/test/java/com/example/delivery/user/application/service/UserServiceUpdateTest.java
+++ b/src/test/java/com/example/delivery/user/application/service/UserServiceUpdateTest.java
@@ -52,12 +52,14 @@ class UserServiceUpdateTest {
     }
 
     @Test
-    @DisplayName("본인은 nickname/email/password/isPublic 모두 수정 가능")
+    @DisplayName("본인은 nickname/email/password/isPublic 모두 수정 가능 (currentPassword 일치)")
     void self_canUpdateAll() {
         given(userRepository.existsByEmailExcept(any(), any())).willReturn(false);
+        given(passwordEncoder.matches("OldPass1!", "hash")).willReturn(true);
         given(passwordEncoder.encode("Abcd1234!")).willReturn("new-hash");
 
-        ReqUpdateUser req = new ReqUpdateUser("NewNick", "new@mail.co", "Abcd1234!", false);
+        ReqUpdateUser req = new ReqUpdateUser(
+                "NewNick", "new@mail.co", "Abcd1234!", "OldPass1!", false);
         LoginUser me = new LoginUser(UUID.randomUUID(), "alice", UserRole.CUSTOMER);
 
         assertThatCode(() -> userService.update("alice", req, me)).doesNotThrowAnyException();
@@ -70,10 +72,46 @@ class UserServiceUpdateTest {
     }
 
     @Test
+    @DisplayName("본인이 password 변경 시 currentPassword 누락 → 400")
+    void self_passwordChange_missingCurrent() {
+        ReqUpdateUser req = new ReqUpdateUser(null, null, "Abcd1234!", null, null);
+        LoginUser me = new LoginUser(UUID.randomUUID(), "alice", UserRole.CUSTOMER);
+
+        assertThatThrownBy(() -> userService.update("alice", req, me))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CURRENT_PASSWORD_REQUIRED);
+        assertThat(target.getPasswordHash()).isEqualTo("hash");
+    }
+
+    @Test
+    @DisplayName("본인이 password 변경 시 currentPassword 불일치 → 401")
+    void self_passwordChange_mismatch() {
+        given(passwordEncoder.matches("WrongOld1!", "hash")).willReturn(false);
+
+        ReqUpdateUser req = new ReqUpdateUser(null, null, "Abcd1234!", "WrongOld1!", null);
+        LoginUser me = new LoginUser(UUID.randomUUID(), "alice", UserRole.CUSTOMER);
+
+        assertThatThrownBy(() -> userService.update("alice", req, me))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_CURRENT_PASSWORD);
+        assertThat(target.getPasswordHash()).isEqualTo("hash");
+    }
+
+    @Test
+    @DisplayName("password 없는 본인 업데이트는 currentPassword 없이도 통과")
+    void self_updateWithoutPassword_doesNotRequireCurrent() {
+        ReqUpdateUser req = new ReqUpdateUser("NewNick", null, null, null, null);
+        LoginUser me = new LoginUser(UUID.randomUUID(), "alice", UserRole.CUSTOMER);
+
+        assertThatCode(() -> userService.update("alice", req, me)).doesNotThrowAnyException();
+        assertThat(target.getNickname()).isEqualTo("NewNick");
+    }
+
+    @Test
     @DisplayName("MANAGER는 타인 수정 가능하나 password 수정 시도는 403")
     void manager_blockedFromPassword() {
         given(passwordEncoder.encode("Abcd1234!")).willReturn("enc");
-        ReqUpdateUser req = new ReqUpdateUser("x", null, "Abcd1234!", null);
+        ReqUpdateUser req = new ReqUpdateUser("x", null, "Abcd1234!", null, null);
         LoginUser me = new LoginUser(UUID.randomUUID(), "bob", UserRole.MANAGER);
 
         assertThatThrownBy(() -> userService.update("alice", req, me))
@@ -89,7 +127,7 @@ class UserServiceUpdateTest {
                 new Email("mo@example.com"), "hash", UserRole.MANAGER);
         given(userRepository.findByUsername("momo")).willReturn(Optional.of(manager));
 
-        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null);
+        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null, null);
         LoginUser other = new LoginUser(UUID.randomUUID(), "mgr2", UserRole.MANAGER);
 
         assertThatThrownBy(() -> userService.update("momo", req, other))
@@ -105,7 +143,7 @@ class UserServiceUpdateTest {
                 new Email("root@example.com"), "hash", UserRole.MASTER);
         given(userRepository.findByUsername("root")).willReturn(Optional.of(master));
 
-        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null);
+        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null, null);
         LoginUser mgr = new LoginUser(UUID.randomUUID(), "mgr1", UserRole.MANAGER);
 
         assertThatThrownBy(() -> userService.update("root", req, mgr))
@@ -121,7 +159,7 @@ class UserServiceUpdateTest {
                 new Email("mo@example.com"), "hash", UserRole.MANAGER);
         given(userRepository.findByUsername("momo")).willReturn(Optional.of(manager));
 
-        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null);
+        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null, null);
         LoginUser master = new LoginUser(UUID.randomUUID(), "root", UserRole.MASTER);
 
         assertThatCode(() -> userService.update("momo", req, master)).doesNotThrowAnyException();
@@ -131,7 +169,7 @@ class UserServiceUpdateTest {
     @Test
     @DisplayName("MASTER는 타인 수정 가능 (password 제외)")
     void master_canUpdateNickname() {
-        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null);
+        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null, null);
         LoginUser me = new LoginUser(UUID.randomUUID(), "root", UserRole.MASTER);
 
         assertThatCode(() -> userService.update("alice", req, me)).doesNotThrowAnyException();
@@ -140,7 +178,7 @@ class UserServiceUpdateTest {
     @Test
     @DisplayName("일반 타인(CUSTOMER)은 타인 수정 시 403")
     void other_forbidden() {
-        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null);
+        ReqUpdateUser req = new ReqUpdateUser("x", null, null, null, null);
         LoginUser me = new LoginUser(UUID.randomUUID(), "bob", UserRole.CUSTOMER);
 
         assertThatThrownBy(() -> userService.update("alice", req, me))
@@ -152,7 +190,7 @@ class UserServiceUpdateTest {
     @DisplayName("본인이 중복 email(다른 사용자 사용 중)로 수정 시 409")
     void self_duplicateEmail() {
         given(userRepository.existsByEmailExcept("taken@mail.co", "alice")).willReturn(true);
-        ReqUpdateUser req = new ReqUpdateUser(null, "taken@mail.co", null, null);
+        ReqUpdateUser req = new ReqUpdateUser(null, "taken@mail.co", null, null, null);
         LoginUser me = new LoginUser(UUID.randomUUID(), "alice", UserRole.CUSTOMER);
 
         assertThatThrownBy(() -> userService.update("alice", req, me))

--- a/src/test/java/com/example/delivery/user/integration/UserAuthIntegrationTest.java
+++ b/src/test/java/com/example/delivery/user/integration/UserAuthIntegrationTest.java
@@ -113,6 +113,29 @@ class UserAuthIntegrationTest {
                 .andExpect(status().isUnauthorized());
     }
 
+    @Test
+    @DisplayName("/users/me - 인증된 요청은 본인 정보 반환")
+    void me_returnsSelf() throws Exception {
+        userRepository.save(UserEntity.register(
+                new Username("eve01"), "이브", new Email("eve@example.com"),
+                passwordEncoder.encode("Abcd1234!"), UserRole.CUSTOMER));
+
+        String token = login("eve01", "Abcd1234!");
+
+        mockMvc.perform(get("/api/v1/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.username").value("eve01"))
+                .andExpect(jsonPath("$.data.role").value("CUSTOMER"));
+    }
+
+    @Test
+    @DisplayName("/users/me - 미인증 요청은 401")
+    void me_unauthenticatedBlocked() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
     private String login(String username, String password) throws Exception {
         String body = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(APPLICATION_JSON)


### PR DESCRIPTION
## Summary

- `GET /api/v1/users/me` 추가 — 기존 `getOne(self, self)` 재사용
- `PATCH /users/{username}` 비밀번호 변경 시 `currentPassword` 필수 + 일치 검증 (토큰 탈취 방어)
- OpenAPI 전역 설정 + Auth/User 엔드포인트·DTO Swagger 문서화

## 주요 리뷰 대상

**기능 (핵심)**
- `user/application/service/UserService.java` — `verifyCurrentPasswordIfChanging`. 본인 + password 요청일 때만 검증, 비본인은 `UserAccessPolicy`가 FORBIDDEN 선차단
- `user/presentation/controller/UserControllerV1.java` — `getMe` 핸들러
- `user/presentation/dto/request/ReqUpdateUser.java` — `currentPassword` 필드
- `global/common/exception/ErrorCode.java` — `CURRENT_PASSWORD_REQUIRED`(400) / `INVALID_CURRENT_PASSWORD`(401)

**Swagger 인프라**
- `global/infrastructure/config/OpenApiConfig.java` — JWT Bearer scheme, info description
- `global/infrastructure/config/SecurityConfig.java` — `/swagger-ui/**`, `/v3/api-docs/**` 공개 경로 명시

## 특이사항

- 공통 `ApiResponse` vs Swagger `@ApiResponse` 이름 충돌로 Swagger 쪽을 FQN으로 사용. IntelliJ 스타일 경고 있으나 기능 영향 없음
- **비범위 (별도 이슈)**: TestAuth 제거

## Test plan

- [x] `./gradlew build` 전체 PASS
- [x] `/users/me` 수동 검증 + Swagger UI Authorize 로컬 확인 완료
- [x] 비밀번호 변경 분기 단위 테스트 통과 — 누락 400 / 불일치 401 / 일치 200 / password 없는 업데이트 무영향
- [x] 기존 `roleMismatch_blocks`, `softDeleted_blocks` 회귀 유지

Closes #30