### PR TITLE
Feature/31 implement order controller

### DIFF
--- a/docs/08-app-flow.md
+++ b/docs/08-app-flow.md
@@ -83,7 +83,52 @@ sequenceDiagram
 
 ## 2. 주문 생성
 
-> **TBD**
+CUSTOMER가 주문을 생성하는 흐름. 컨트롤러 진입 이후 서비스는 트랜잭션 경계·조립만 담당하고, 상태 전이/불변식은 `OrderEntity`가 스스로 검증한다.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Client as 클라이언트 (CUSTOMER)
+  participant F as JwtAuthenticationFilter
+  participant C as OrderControllerV1
+  participant S as OrderServiceV1
+  participant OE as OrderEntity<br/>/OrderItemEntity
+  participant R as OrderRepository
+  participant DB as PostgreSQL
+
+  Note over Client,F: 인증 파이프라인은 §1 참조
+
+  Client ->> F: 주문 생성 요청
+  F ->> C: 인증 통과 후 컨트롤러로 위임
+  C ->> C: 요청 DTO 물리 검증
+  C ->> S: 서비스 호출 (트랜잭션 시작)
+
+  S ->> S: 주문 총액 계산 (스냅샷)
+  S ->> OE: 주문 엔티티 생성
+
+  loop 각 주문 항목 반복
+    S ->> OE: 주문 항목 엔티티 생성
+    Note right of OE: 엔티티 불변식 검증
+    S ->> OE: 주문-항목 연관관계 연결
+  end
+
+  S ->> R: 주문 영속화 요청
+  R ->> DB: 주문 + 항목 INSERT (cascade)
+  DB -->> R: 영속 엔티티 반환
+  R -->> S: 저장된 주문 반환
+  S -->> C: 응답 DTO 변환 (트랜잭션 커밋)
+  C -->> Client: 생성된 주문 응답
+
+  Note right of S: 실패 시 VALIDATION_ERROR 등으로<br/>예외 응답 반환
+```
+
+**설계 포인트**
+
+- **주문 시점 스냅샷**: `totalPrice`는 서비스가 클라이언트 입력 `quantity × unitPrice`로 계산해 저장. 이후 메뉴 가격이 바뀌거나 메뉴가 삭제되어도 과거 주문 금액은 불변.
+- **물리 검증(@Valid) vs 논리 불변식**: DTO 레이어에서 `@NotNull`/`@Min` 같은 물리 검증을 먼저 걷어내고, `OrderItemEntity` 생성자가 `quantity > 0` / `unitPrice ≥ 0` 논리 불변식을 한 번 더 방어한다.
+- **Cascade ALL + orphanRemoval**: `OrderItemEntity`는 별도 save 호출 없이 `addItem()` → `orderRepository.save(order)` 한 번으로 함께 영속화된다.
+- **도메인 로직 위임**: 서비스는 트랜잭션 경계·조립만 담당하고, 상태 전이/불변식 검증은 `OrderEntity`가 스스로 수행한다 (DDD 관점).
+- **Soft Delete**: `@SQLRestriction("deleted_at IS NULL")` 로 조회 시 자동 제외.
 
 ## 3. 결제 (Fake / 실 PG)
 

--- a/src/main/java/com/example/delivery/global/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/example/delivery/global/infrastructure/config/SecurityConfig.java
@@ -65,6 +65,10 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/orders/*/reviews").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/api/v1/reviews/*").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/reviews/*").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/orders").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/orders/*/cancel").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/orders/*/status").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/orders/*/request").authenticated()
                         .anyRequest().permitAll())
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider, userRepository, objectMapper),

--- a/src/main/java/com/example/delivery/order/presentation/controller/OrderControllerV1.java
+++ b/src/main/java/com/example/delivery/order/presentation/controller/OrderControllerV1.java
@@ -1,0 +1,188 @@
+package com.example.delivery.order.presentation.controller;
+
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+import com.example.delivery.global.common.response.ApiResponse;
+import com.example.delivery.global.infrastructure.security.UserPrincipal;
+import com.example.delivery.order.application.service.OrderServiceV1;
+import com.example.delivery.order.domain.entity.OrderStatus;
+import com.example.delivery.order.presentation.dto.request.ReqChangeStatusDto;
+import com.example.delivery.order.presentation.dto.request.ReqCreateOrderDto;
+import com.example.delivery.order.presentation.dto.request.ReqUpdateRequestDto;
+import com.example.delivery.order.presentation.dto.response.ResOrderDto;
+import com.example.delivery.user.domain.entity.UserRole;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 주문 컨트롤러 V1.
+ *
+ * [역할 분담]
+ * 서비스 레이어의 메서드는 역할별로 나뉘어 있으므로 컨트롤러가 {@link UserPrincipal#role()}을 보고
+ * 올바른 서비스 메서드로 디스패치(허용되지 않은 role은 403 FORBIDDEN.)
+ *
+ * [본인 확인]
+ * CUSTOMER가 본인 주문에만 접근하도록 {@link #verifyOwner}가 {@code getOrder}로 주문을
+ * 다시 조회해 {@code customerId}를 비교한다. 서비스 쪽 쓰기 트랜잭션 전에 한 번 더 조회가
+ * 발생하므로 향후 서비스/엔티티 쪽으로 이 검증을 내리면 호출 1회로 줄일 수 있다.
+ *
+ * [응답 규약]
+ * 모든 응답은 {@link ApiResponse}로 감싸며, 예외는 GlobalExceptionHandler에서 공통 포맷으로
+ * 변환된다.
+ */
+@Tag(name = "Order", description = "주문 API")
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderControllerV1 {
+
+    private final OrderServiceV1 orderService;
+
+    @Operation(summary = "주문 생성", description = "CUSTOMER가 장바구니 항목으로 주문을 생성합니다. (인증 필요)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "주문 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 본문 검증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CUSTOMER 권한 아님")
+    })
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<ResOrderDto> createOrder(
+            @RequestBody @Valid ReqCreateOrderDto request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        requireRole(principal, UserRole.CUSTOMER);
+        return ApiResponse.created(orderService.createOrder(principal.username(), request));
+    }
+
+    @Operation(summary = "주문 단건 조회", description = "주문 ID로 주문을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문 없음")
+    })
+    @GetMapping("/{orderId}")
+    public ApiResponse<ResOrderDto> getOrder(
+            @Parameter(description = "주문 ID") @PathVariable UUID orderId
+    ) {
+        return ApiResponse.ok(orderService.getOrder(orderId));
+    }
+
+
+    @Operation(summary = "주문 목록 조회", description = "페이지네이션으로 주문 목록을 조회합니다.")
+    @GetMapping
+    public ApiResponse<Page<ResOrderDto>> getOrders(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ApiResponse.ok(orderService.getOrders(pageable));
+    }
+
+
+    @Operation(summary = "주문 취소",
+            description = "CUSTOMER는 본인 주문 한정(PENDING + 5분 이내), MASTER는 제약 없이 취소합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "취소 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "상태/시간 조건 불충족"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문 없음")
+    })
+    @PostMapping("/{orderId}/cancel")
+    public ApiResponse<ResOrderDto> cancelOrder(
+            @Parameter(description = "주문 ID") @PathVariable UUID orderId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return switch (principal.role()) {
+            case MASTER -> ApiResponse.ok(orderService.cancelByMaster(orderId));
+            case CUSTOMER -> {
+                verifyOwner(orderId, principal);
+                yield ApiResponse.ok(orderService.cancelByCustomer(orderId));
+            }
+            default -> throw new BusinessException(ErrorCode.FORBIDDEN);
+        };
+    }
+
+
+    @Operation(summary = "주문 상태 변경",
+            description = "OWNER는 정방향 전이, MANAGER는 CANCELLED 제외 자유 전이, MASTER는 제약 없음.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "허용되지 않는 상태 전이"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문 없음")
+    })
+    @PatchMapping("/{orderId}/status")
+    public ApiResponse<ResOrderDto> changeStatus(
+            @Parameter(description = "주문 ID") @PathVariable UUID orderId,
+            @RequestBody @Valid ReqChangeStatusDto request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        OrderStatus next = request.status();
+        return switch (principal.role()) {
+            case OWNER -> ApiResponse.ok(orderService.changeStatusByOwner(orderId, next));
+            case MANAGER -> ApiResponse.ok(orderService.changeStatusByManager(orderId, next));
+            case MASTER -> ApiResponse.ok(orderService.changeStatusByMaster(orderId, next));
+            default -> throw new BusinessException(ErrorCode.FORBIDDEN);
+        };
+    }
+
+    @Operation(summary = "주문 요청사항 수정",
+            description = "PENDING 상태에서만 수정 가능. CUSTOMER는 본인 주문만, MASTER는 모든 주문 수정 가능.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "PENDING 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문 없음")
+    })
+    @PatchMapping("/{orderId}/request")
+    public ApiResponse<ResOrderDto> updateRequest(
+            @Parameter(description = "주문 ID") @PathVariable UUID orderId,
+            @RequestBody @Valid ReqUpdateRequestDto request,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        if (principal.role() == UserRole.CUSTOMER) {
+            verifyOwner(orderId, principal);
+        } else if (principal.role() != UserRole.MASTER) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return ApiResponse.ok(orderService.updateRequest(orderId, request.request()));
+    }
+
+    /** 특정 단일 role만 허용. 위반 시 403. */
+    private void requireRole(UserPrincipal principal, UserRole expected) {
+        if (principal.role() != expected) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+    /**
+     * 주문의 {@code customerId}가 요청자의 {@code username}과 일치하는지 확인한다.
+     * 불일치 시 403. 주문이 없으면 {@code getOrder}에서 ORDER_NOT_FOUND(404)로 먼저 종료된다.
+     */
+    private void verifyOwner(UUID orderId, UserPrincipal principal) {
+        ResOrderDto order = orderService.getOrder(orderId);
+        if (!order.customerId().equals(principal.username())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/example/delivery/order/presentation/dto/request/ReqChangeStatusDto.java
+++ b/src/main/java/com/example/delivery/order/presentation/dto/request/ReqChangeStatusDto.java
@@ -1,0 +1,14 @@
+package com.example.delivery.order.presentation.dto.request;
+
+import com.example.delivery.order.domain.entity.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "주문 상태 변경 요청 DTO")
+public record ReqChangeStatusDto(
+
+        @Schema(description = "변경할 주문 상태", example = "ACCEPTED")
+        @NotNull(message = "상태는 필수입니다.")
+        OrderStatus status
+) {
+}

--- a/src/main/java/com/example/delivery/order/presentation/dto/request/ReqUpdateRequestDto.java
+++ b/src/main/java/com/example/delivery/order/presentation/dto/request/ReqUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.delivery.order.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "주문 요청사항 수정 DTO")
+public record ReqUpdateRequestDto(
+
+        @Schema(description = "요청사항", example = "문 앞에 두고 가주세요.")
+        @Size(max = 500, message = "요청사항은 최대 500자까지 가능합니다.")
+        String request
+) {
+}

--- a/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
+++ b/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
@@ -1,0 +1,513 @@
+package com.example.delivery.order.presentation.controller;
+
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+import com.example.delivery.global.infrastructure.config.SecurityConfig;
+import com.example.delivery.global.infrastructure.security.JwtTokenProvider;
+import com.example.delivery.global.infrastructure.security.RestAccessDeniedHandler;
+import com.example.delivery.global.infrastructure.security.RestAuthenticationEntryPoint;
+import com.example.delivery.global.infrastructure.security.UserPrincipal;
+import com.example.delivery.order.application.service.OrderServiceV1;
+import com.example.delivery.order.domain.entity.OrderStatus;
+import com.example.delivery.order.domain.entity.OrderType;
+import com.example.delivery.order.presentation.dto.request.ReqChangeStatusDto;
+import com.example.delivery.order.presentation.dto.request.ReqCreateOrderDto;
+import com.example.delivery.order.presentation.dto.request.ReqOrderItemDto;
+import com.example.delivery.order.presentation.dto.request.ReqUpdateRequestDto;
+import com.example.delivery.order.presentation.dto.response.ResOrderDto;
+import com.example.delivery.user.domain.entity.UserRole;
+import com.example.delivery.user.domain.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@link OrderControllerV1} WebMvc 테스트.
+ *
+ * [테스트 전략]
+ * - {@code @WebMvcTest}로 컨트롤러 슬라이스만 로드하고, 서비스·JWT·인증 예외 핸들러는
+ *   {@link MockBean}으로 대체한다 → 컨트롤러의 요청 매핑·role 분기·본인 확인 로직에만 집중.
+ * - {@link SecurityConfig}는 {@code @Import}로 끌어와 실제 URL 매처/인증 필터 동작까지 검증.
+ *
+ * [인증 흐름 모킹]
+ * - 인증 없음 → {@code RestAuthenticationEntryPoint}가 401을 반환하도록 스텁.
+ * - 권한 없음 → {@code RestAccessDeniedHandler}가 403을 반환하도록 스텁.
+ * - 인증 필요 테스트는 {@code SecurityMockMvcRequestPostProcessors.authentication}으로
+ *   {@link UsernamePasswordAuthenticationToken}을 직접 주입 (JWT 파싱 우회).
+ *
+ * [role 별 픽스처]
+ * CUSTOMER(본인/타인) · OWNER · MANAGER · MASTER — 컨트롤러 디스패치 분기를 모두 커버.
+ */
+@WebMvcTest(OrderControllerV1.class)
+@Import(SecurityConfig.class)
+class OrderControllerV1Test {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean OrderServiceV1 orderService;
+    @MockBean JwtTokenProvider jwtTokenProvider;
+    @MockBean RestAuthenticationEntryPoint authenticationEntryPoint;
+    @MockBean RestAccessDeniedHandler accessDeniedHandler;
+    // SecurityConfig의 JwtAuthenticationFilter가 UserRepository를 요구 — 슬라이스 테스트에선 미등록이라 직접 모킹.
+    @MockBean UserRepository userRepository;
+
+    // ─── 공통 픽스처 ─────────────────────────────────────────────────
+    private static final String CUSTOMER_NAME = "cust01";
+    private static final UUID ORDER_ID   = UUID.randomUUID();
+    private static final UUID STORE_ID   = UUID.randomUUID();
+    private static final UUID ADDRESS_ID = UUID.randomUUID();
+
+    // 본인 확인 로직 검증을 위해 CUSTOMER는 2명(cust01, other)을 준비한다.
+    private final UserPrincipal customer  = new UserPrincipal(UUID.randomUUID(), CUSTOMER_NAME, UserRole.CUSTOMER);
+    private final UserPrincipal otherUser = new UserPrincipal(UUID.randomUUID(), "other",       UserRole.CUSTOMER);
+    private final UserPrincipal owner     = new UserPrincipal(UUID.randomUUID(), "owner",       UserRole.OWNER);
+    private final UserPrincipal manager   = new UserPrincipal(UUID.randomUUID(), "manager",     UserRole.MANAGER);
+    private final UserPrincipal master    = new UserPrincipal(UUID.randomUUID(), "master",      UserRole.MASTER);
+
+    /**
+     * 인증/인가 실패 시의 HTTP 상태 코드를 테스트 스텁으로 고정.
+     * (실제 엔트리포인트/핸들러 로직은 별도 테스트에서 검증.)
+     */
+    @BeforeEach
+    void setupSecurityHandlers() throws Exception {
+        doAnswer(invocation -> {
+            HttpServletResponse response = invocation.getArgument(1);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }).when(authenticationEntryPoint).commence(any(), any(), any());
+
+        doAnswer(invocation -> {
+            HttpServletResponse response = invocation.getArgument(1);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return null;
+        }).when(accessDeniedHandler).handle(any(), any(), any());
+    }
+
+    /** 주어진 principal로 인증된 토큰을 구성. ROLE_ 접두사는 Spring Security 컨벤션. */
+    private UsernamePasswordAuthenticationToken auth(UserPrincipal p) {
+        return new UsernamePasswordAuthenticationToken(
+                p, null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + p.role().name())));
+    }
+
+    /** 응답 DTO 샘플 — 테스트에서 서비스 반환값을 스텁할 때 사용. */
+    private ResOrderDto sampleOrder(String customerId, OrderStatus status) {
+        return new ResOrderDto(
+                ORDER_ID, customerId, STORE_ID, ADDRESS_ID,
+                OrderType.ONLINE, status, 40_000, "요청",
+                List.of()
+        );
+    }
+
+    // ── createOrder ─────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("POST /api/v1/orders — 주문 생성")
+    class CreateOrder {
+
+        private ReqCreateOrderDto validRequest() {
+            return new ReqCreateOrderDto(
+                    STORE_ID, ADDRESS_ID, "요청사항",
+                    List.of(new ReqOrderItemDto(UUID.randomUUID(), 2, 18_000))
+            );
+        }
+
+        @Test
+        @DisplayName("성공 — CUSTOMER 가 201 Created")
+        void success() throws Exception {
+            // principal.username() 이 서비스의 customerId 인자로 그대로 전달되는지 확인
+            given(orderService.createOrder(eq(CUSTOMER_NAME), any()))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+
+            mockMvc.perform(post("/api/v1/orders")
+                            .with(authentication(auth(customer)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validRequest())))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.status").value("PENDING"));
+        }
+
+        @Test
+        @DisplayName("실패 — 인증 없음 401")
+        void unauthorized() throws Exception {
+            // SecurityConfig의 authenticated() 매처가 걸러 authenticationEntryPoint로 위임됨
+            mockMvc.perform(post("/api/v1/orders")
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validRequest())))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패 — CUSTOMER 아니면 403")
+        void forbidden_notCustomer() throws Exception {
+            // 인증은 되어 있지만 role이 OWNER → requireRole()에서 FORBIDDEN
+            mockMvc.perform(post("/api/v1/orders")
+                            .with(authentication(auth(owner)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validRequest())))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 — 주문 항목 빈 배열 400")
+        void invalid_emptyItems() throws Exception {
+            // @NotEmpty 위반 → MethodArgumentNotValidException → 400
+            ReqCreateOrderDto req = new ReqCreateOrderDto(STORE_ID, ADDRESS_ID, "요청", List.of());
+
+            mockMvc.perform(post("/api/v1/orders")
+                            .with(authentication(auth(customer)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    // ── getOrder ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("GET /api/v1/orders/{orderId} — 단건 조회")
+    class GetOrder {
+
+        @Test
+        @DisplayName("성공 — 200 OK")
+        void success() throws Exception {
+            given(orderService.getOrder(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+
+            // 인증 없이도 조회 가능 (SecurityConfig의 anyRequest().permitAll())
+            mockMvc.perform(get("/api/v1/orders/{orderId}", ORDER_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.orderId").value(ORDER_ID.toString()));
+        }
+
+        @Test
+        @DisplayName("실패 — 존재하지 않는 주문 404")
+        void notFound() throws Exception {
+            // 서비스가 ORDER_NOT_FOUND 던짐 → GlobalExceptionHandler가 404로 매핑
+            given(orderService.getOrder(ORDER_ID))
+                    .willThrow(new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+            mockMvc.perform(get("/api/v1/orders/{orderId}", ORDER_ID))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    // ── getOrders ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("GET /api/v1/orders — 목록 조회")
+    class GetOrders {
+
+        @Test
+        @DisplayName("성공 — 페이지 반환")
+        void success() throws Exception {
+            // Page<ResOrderDto>가 JSON 직렬화되어 totalElements가 내려오는지 확인
+            Page<ResOrderDto> page = new PageImpl<>(
+                    List.of(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING)),
+                    PageRequest.of(0, 10), 1);
+            given(orderService.getOrders(any())).willReturn(page);
+
+            mockMvc.perform(get("/api/v1/orders"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+    }
+
+    // ── cancelOrder ─────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("POST /api/v1/orders/{orderId}/cancel — 주문 취소")
+    class CancelOrder {
+
+        @Test
+        @DisplayName("성공 — CUSTOMER 본인")
+        void customerOwner_success() throws Exception {
+            // verifyOwner가 getOrder로 customerId를 검증하므로 getOrder도 스텁 필요
+            given(orderService.getOrder(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+            given(orderService.cancelByCustomer(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.CANCELLED));
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
+                            .with(authentication(auth(customer)))
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("CANCELLED"));
+        }
+
+        @Test
+        @DisplayName("실패 — CUSTOMER 타인 주문 403")
+        void customerOther_forbidden() throws Exception {
+            // getOrder가 cust01 소유를 반환 → 요청자는 other → verifyOwner에서 FORBIDDEN
+            given(orderService.getOrder(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
+                            .with(authentication(auth(otherUser)))
+                            .with(csrf()))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("성공 — MASTER 는 타인 주문도 취소")
+        void master_success() throws Exception {
+            // MASTER는 verifyOwner를 거치지 않고 cancelByMaster로 바로 진입
+            given(orderService.cancelByMaster(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.CANCELLED));
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
+                            .with(authentication(auth(master)))
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("실패 — OWNER/MANAGER 는 취소 불가 403")
+        void ownerOrManager_forbidden() throws Exception {
+            // switch 의 default 분기로 들어가 FORBIDDEN
+            mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
+                            .with(authentication(auth(owner)))
+                            .with(csrf()))
+                    .andExpect(status().isForbidden());
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
+                            .with(authentication(auth(manager)))
+                            .with(csrf()))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 — 인증 없음 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
+                            .with(csrf()))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패 — CUSTOMER 5분 초과 시 400")
+        void customer_timeout() throws Exception {
+            // 본인 확인은 통과하지만 엔티티에서 ORDER_CANCEL_TIMEOUT 발생
+            given(orderService.getOrder(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+            given(orderService.cancelByCustomer(ORDER_ID))
+                    .willThrow(new BusinessException(ErrorCode.ORDER_CANCEL_TIMEOUT));
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
+                            .with(authentication(auth(customer)))
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    // ── changeStatus ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("PATCH /api/v1/orders/{orderId}/status — 상태 변경")
+    class ChangeStatus {
+
+        /** JSON 본문 생성 헬퍼 — 테스트마다 status만 바꿔서 재사용. */
+        private String body(OrderStatus status) throws Exception {
+            return objectMapper.writeValueAsString(new ReqChangeStatusDto(status));
+        }
+
+        @Test
+        @DisplayName("성공 — OWNER 정방향")
+        void owner_success() throws Exception {
+            // OWNER → changeStatusByOwner 로 디스패치 확인
+            given(orderService.changeStatusByOwner(ORDER_ID, OrderStatus.ACCEPTED))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.ACCEPTED));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/status", ORDER_ID)
+                            .with(authentication(auth(owner)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body(OrderStatus.ACCEPTED)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("ACCEPTED"));
+        }
+
+        @Test
+        @DisplayName("실패 — OWNER 역방향 전이 400")
+        void owner_invalidTransition() throws Exception {
+            // 엔티티의 canTransitionTo가 false → INVALID_ORDER_STATUS
+            given(orderService.changeStatusByOwner(eq(ORDER_ID), any()))
+                    .willThrow(new BusinessException(ErrorCode.INVALID_ORDER_STATUS));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/status", ORDER_ID)
+                            .with(authentication(auth(owner)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body(OrderStatus.COOKING)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("성공 — MANAGER CANCELLED 외 전이")
+        void manager_success() throws Exception {
+            given(orderService.changeStatusByManager(ORDER_ID, OrderStatus.DELIVERING))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.DELIVERING));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/status", ORDER_ID)
+                            .with(authentication(auth(manager)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body(OrderStatus.DELIVERING)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("성공 — MASTER 임의 전이")
+        void master_success() throws Exception {
+            // MASTER는 제약 없으므로 역방향(DELIVERED → PENDING)도 허용
+            given(orderService.changeStatusByMaster(ORDER_ID, OrderStatus.PENDING))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/status", ORDER_ID)
+                            .with(authentication(auth(master)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body(OrderStatus.PENDING)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("실패 — CUSTOMER 는 상태 변경 불가 403")
+        void customer_forbidden() throws Exception {
+            // switch default 분기 → FORBIDDEN (서비스 호출 자체가 없음)
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/status", ORDER_ID)
+                            .with(authentication(auth(customer)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body(OrderStatus.ACCEPTED)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ── updateRequest ───────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("PATCH /api/v1/orders/{orderId}/request — 요청사항 수정")
+    class UpdateRequest {
+
+        private String body(String request) throws Exception {
+            return objectMapper.writeValueAsString(new ReqUpdateRequestDto(request));
+        }
+
+        @Test
+        @DisplayName("성공 — CUSTOMER 본인")
+        void customerOwner_success() throws Exception {
+            given(orderService.getOrder(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+            given(orderService.updateRequest(ORDER_ID, "수정"))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
+                            .with(authentication(auth(customer)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body("수정")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("실패 — CUSTOMER 타인 주문 403")
+        void customerOther_forbidden() throws Exception {
+            // 본인 확인 실패 → 서비스 updateRequest 호출 없이 FORBIDDEN
+            given(orderService.getOrder(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
+                            .with(authentication(auth(otherUser)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body("수정")))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("성공 — MASTER 는 타인 주문도 수정")
+        void master_success() throws Exception {
+            // MASTER는 verifyOwner를 건너뛰고 바로 updateRequest 호출
+            given(orderService.updateRequest(ORDER_ID, "수정"))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
+                            .with(authentication(auth(master)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body("수정")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("실패 — OWNER/MANAGER 는 수정 불가 403")
+        void ownerOrManager_forbidden() throws Exception {
+            // CUSTOMER/MASTER 외 전부 FORBIDDEN
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
+                            .with(authentication(auth(owner)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body("수정")))
+                    .andExpect(status().isForbidden());
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
+                            .with(authentication(auth(manager)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body("수정")))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("실패 — PENDING 아니면 400")
+        void notPending() throws Exception {
+            // 본인 확인은 통과, 엔티티 레벨에서 PENDING 아님 → INVALID_ORDER_STATUS
+            given(orderService.getOrder(ORDER_ID))
+                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.COOKING));
+            given(orderService.updateRequest(ORDER_ID, "수정"))
+                    .willThrow(new BusinessException(ErrorCode.INVALID_ORDER_STATUS));
+
+            mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
+                            .with(authentication(auth(customer)))
+                            .with(csrf())
+                            .contentType(APPLICATION_JSON)
+                            .content(body("수정")))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}


### PR DESCRIPTION
## 개요
- 주문 도메인 Controller 레이어 추가
- OrderServiceV1의 role별 메서드를 외부 API로 노출
- 인증/인가, role 디스패치, 본인 확인 분기를 슬라이스 테스트로 검증

## 구현 내용

### API 엔드포인트

| Method | URI | 설명 | 인증 |
|--------|-----|------|------|
| POST | `/api/v1/orders` | 주문 생성 | CUSTOMER |
| GET | `/api/v1/orders/{orderId}` | 단건 조회 | 불필요 |
| GET | `/api/v1/orders` | 페이지네이션 목록 | 불필요 |
| POST | `/api/v1/orders/{orderId}/cancel` | 주문 취소 | CUSTOMER(본인) / MASTER |
| PATCH | `/api/v1/orders/{orderId}/status` | 상태 변경 | OWNER / MANAGER / MASTER |
| PATCH | `/api/v1/orders/{orderId}/request` | 요청사항 수정 | CUSTOMER(본인) / MASTER |

### Presentation 레이어
- OrderControllerV1 신설
- verifyOwner(orderId, principal)로 CUSTOMER 본인 주문 검증
- 요청 DTO 추가: ReqChangeStatusDto, ReqUpdateRequestDto
- Swagger @Operation / @ApiResponses로 응답 명세

### SecurityConfig
- 주문 생성/취소/상태변경/요청수정 → authenticated()
- 단건/목록 조회 → permitAll()

### 테스트
- OrderControllerV1Test: @WebMvcTest + @Import(SecurityConfig.class), 23개 케이스
- 인증 실패(401) / 권한 실패(403) 검증용 RestAuthenticationEntryPoint, RestAccessDeniedHandler 스텁
- role별(CUSTOMER 본인/타인, OWNER, MANAGER, MASTER) 분기 전수 커버
- 예외 경로: INVALID_ORDER_STATUS, ORDER_CANCEL_TIMEOUT, ORDER_NOT_FOUND, @NotEmpty 위반

## 참고사항
- verifyOwner DB 중복 조회 구조 개선 예정

## 연관 이슈
- Closes #31