### PR TITLE
Feature: Store CRUD 구현 (#27)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -42,4 +48,19 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// QueryDSL 생성 소스 디렉토리 (.gitignore 의 /src/main/generated 와 정합)
+def querydslGeneratedDir = 'src/main/generated'
+
+sourceSets {
+    main.java.srcDirs += [querydslGeneratedDir]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslGeneratedDir)
+}
+
+clean {
+    delete file(querydslGeneratedDir)
 }

--- a/src/main/java/com/example/delivery/category/infrastructure/init/CategoryDataInitializer.java
+++ b/src/main/java/com/example/delivery/category/infrastructure/init/CategoryDataInitializer.java
@@ -1,0 +1,50 @@
+package com.example.delivery.category.infrastructure.init;
+
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 애플리케이션 기동 시 기본 카테고리(한식/중식/분식/치킨/피자)를 삽입함
+ */
+@Slf4j
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class CategoryDataInitializer implements ApplicationRunner {
+
+    private static final List<String> DEFAULT_CATEGORY_NAMES =
+            List.of("한식", "중식", "분식", "치킨", "피자");
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        List<String> inserted = new ArrayList<>();
+
+        for (String name : DEFAULT_CATEGORY_NAMES) {
+            if (categoryRepository.findByName(name).isPresent()) {
+                continue;
+            }
+            categoryRepository.save(CategoryEntity.builder().name(name).build());
+            inserted.add(name);
+        }
+
+        if (inserted.isEmpty()) {
+            log.info("[CategoryDataInitializer] 기본 카테고리가 이미 모두 존재합니다. 스킵합니다.");
+        } else {
+            log.info("[CategoryDataInitializer] 기본 카테고리 {}건 초기화 완료: {}",
+                    inserted.size(), inserted);
+        }
+    }
+}

--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
 
     //Menu
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),
-    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게룰 찾을 수 없습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다."),
 
     //AI
     AI_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "AI 요청 기록을 찾을 수 없습니다."),
@@ -52,6 +52,15 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
     DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 해당 주문에 리뷰를 작성했습니다."),
     ORDER_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "완료된 주문에만 리뷰를 작성할 수 있습니다."),
+
+    // Store
+    STORE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 가게에 대한 권한이 없습니다."),
+    STORE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "가게명은 필수입니다."),
+    STORE_ADDRESS_REQUIRED(HttpStatus.BAD_REQUEST, "가게 주소는 필수입니다."),
+    STORE_AREA_REQUIRED(HttpStatus.BAD_REQUEST, "지역 ID는 필수입니다."),
+    STORE_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "카테고리 ID는 필수입니다."),
+    INVALID_STORE_RATING(HttpStatus.BAD_REQUEST, "가게 평균 평점 값이 올바르지 않습니다."),
+    STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 소유자가 이미 동일한 이름의 가게를 보유하고 있습니다."),
 
     // Area
     AREA_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "삭제된 지역명입니다."),

--- a/src/main/java/com/example/delivery/global/infrastructure/config/QuerydslConfig.java
+++ b/src/main/java/com/example/delivery/global/infrastructure/config/QuerydslConfig.java
@@ -1,0 +1,23 @@
+package com.example.delivery.global.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * QueryDSL 공통 설정
+ * JPAQueryFactory 를 Bean 으로 등록하여 Custom Repository 구현체에서 주입받아 사용함
+ */
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/delivery/store/application/exception/RelatedAreaNotFoundException.java
+++ b/src/main/java/com/example/delivery/store/application/exception/RelatedAreaNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.delivery.store.application.exception;
+
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+
+public class RelatedAreaNotFoundException extends BusinessException {
+
+    public RelatedAreaNotFoundException() {
+        super(ErrorCode.AREA_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/delivery/store/application/exception/RelatedCategoryNotFoundException.java
+++ b/src/main/java/com/example/delivery/store/application/exception/RelatedCategoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.delivery.store.application.exception;
+
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+
+public class RelatedCategoryNotFoundException extends BusinessException {
+
+    public RelatedCategoryNotFoundException() {
+        super(ErrorCode.CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/delivery/store/application/exception/StoreAccessDeniedException.java
+++ b/src/main/java/com/example/delivery/store/application/exception/StoreAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.example.delivery.store.application.exception;
+
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+
+public class StoreAccessDeniedException extends BusinessException {
+
+    public StoreAccessDeniedException() {
+        super(ErrorCode.STORE_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/example/delivery/store/application/exception/StoreNotFoundException.java
+++ b/src/main/java/com/example/delivery/store/application/exception/StoreNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.delivery.store.application.exception;
+
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+
+public class StoreNotFoundException extends BusinessException {
+
+    public StoreNotFoundException() {
+        super(ErrorCode.STORE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
+++ b/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
@@ -1,0 +1,178 @@
+package com.example.delivery.store.application.service;
+
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+import com.example.delivery.global.common.response.PageResponse;
+import com.example.delivery.global.infrastructure.security.UserPrincipal;
+import com.example.delivery.store.application.exception.RelatedAreaNotFoundException;
+import com.example.delivery.store.application.exception.RelatedCategoryNotFoundException;
+import com.example.delivery.store.application.exception.StoreAccessDeniedException;
+import com.example.delivery.store.application.exception.StoreNotFoundException;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import com.example.delivery.store.presentation.dto.request.ReqCreateStoreDto;
+import com.example.delivery.store.presentation.dto.request.ReqUpdateStoreDto;
+import com.example.delivery.store.presentation.dto.response.ResCreateStoreDto;
+import com.example.delivery.store.presentation.dto.response.ResGetStoreDto;
+import com.example.delivery.user.domain.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static com.example.delivery.global.common.pageable.PageableUtils.createPageable;
+import static com.example.delivery.global.common.pageable.PageableUtils.hasKeyword;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreServiceV1 {
+
+    private final StoreRepository storeRepository;
+    private final AreaRepository areaRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public ResCreateStoreDto createStore(ReqCreateStoreDto request, UUID ownerId) {
+
+        String storeName = request.name().trim();
+        String address = request.address().trim();
+        String phone = trimToNull(request.phone());
+
+        validateCategoryExists(request.categoryId());
+        validateAreaExists(request.areaId());
+        validateDuplicateStoreName(ownerId, storeName);
+
+        StoreEntity store = StoreEntity.builder()
+                .ownerId(ownerId)
+                .categoryId(request.categoryId())
+                .areaId(request.areaId())
+                .name(storeName)
+                .address(address)
+                .phone(phone)
+                .build();
+
+        return ResCreateStoreDto.from(storeRepository.save(store));
+    }
+
+    public PageResponse<ResGetStoreDto> getAllStores(String keyword, UUID categoryId, UUID areaId, int page, int size) {
+
+        Pageable pageable = createPageable(page, size);
+        String normalizedKeyword = hasKeyword(keyword) ? keyword.trim() : null;
+
+        Page<ResGetStoreDto> result = storeRepository
+                .search(normalizedKeyword, categoryId, areaId, pageable)
+                .map(ResGetStoreDto::from);
+
+        return PageResponse.from(result);
+    }
+
+    public ResGetStoreDto getStore(UUID storeId) {
+        return ResGetStoreDto.from(getStoreEntity(storeId));
+    }
+
+    @Transactional
+    public ResGetStoreDto updateStore(UUID storeId, ReqUpdateStoreDto request, UserPrincipal principal) {
+
+        StoreEntity store = getStoreEntity(storeId);
+        assertModifiable(store, principal);
+
+        validateCategoryExists(request.categoryId());
+        validateAreaExists(request.areaId());
+
+        String newName = request.name().trim();
+        // 이름이 바뀌는 경우에만 동일 소유자 내 중복 검증 (자기 자신은 제외)
+        if (!store.getName().equals(newName)) {
+            validateDuplicateStoreName(store.getOwnerId(), newName);
+        }
+
+        store.update(
+                request.categoryId(),
+                request.areaId(),
+                newName,
+                request.address().trim(),
+                trimToNull(request.phone())
+        );
+
+        return ResGetStoreDto.from(store);
+    }
+
+    @Transactional
+    public ResGetStoreDto toggleHiddenStore(UUID storeId, UserPrincipal principal) {
+
+        StoreEntity store = getStoreEntity(storeId);
+        assertModifiable(store, principal);
+
+        store.toggleHidden();
+
+        return ResGetStoreDto.from(store);
+    }
+
+    @Transactional
+    public void deleteStore(UUID storeId, UserPrincipal principal) {
+
+        StoreEntity store = getStoreEntity(storeId);
+        assertDeletable(store, principal);
+
+        store.softDelete(principal.username());
+    }
+
+    private StoreEntity getStoreEntity(UUID storeId) {
+        return storeRepository.findById(storeId)
+                .orElseThrow(StoreNotFoundException::new);
+    }
+
+    private void validateCategoryExists(UUID categoryId) {
+        if (categoryRepository.findById(categoryId).isEmpty()) {
+            throw new RelatedCategoryNotFoundException();
+        }
+    }
+
+    private void validateAreaExists(UUID areaId) {
+        if (areaRepository.findById(areaId).isEmpty()) {
+            throw new RelatedAreaNotFoundException();
+        }
+    }
+
+    private void validateDuplicateStoreName(UUID ownerId, String storeName) {
+        if (storeRepository.findByOwnerIdAndName(ownerId, storeName).isPresent()) {
+            throw new BusinessException(ErrorCode.STORE_ALREADY_EXISTS);
+        }
+    }
+
+    /** PATCH (수정 / 숨김 토글) 권한: OWNER(본인) / MANAGER / MASTER */
+    private void assertModifiable(StoreEntity store, UserPrincipal principal) {
+        UserRole role = principal.role();
+        if (role == UserRole.MANAGER || role == UserRole.MASTER) {
+            return;
+        }
+        if (role == UserRole.OWNER && store.isOwnedBy(principal.id())) {
+            return;
+        }
+        throw new StoreAccessDeniedException();
+    }
+
+    /** DELETE 권한: OWNER(본인) / MASTER (MANAGER 불가) */
+    private void assertDeletable(StoreEntity store, UserPrincipal principal) {
+        UserRole role = principal.role();
+        if (role == UserRole.MASTER) {
+            return;
+        }
+        if (role == UserRole.OWNER && store.isOwnedBy(principal.id())) {
+            return;
+        }
+        throw new StoreAccessDeniedException();
+    }
+
+    private String trimToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/example/delivery/store/domain/entity/StoreEntity.java
+++ b/src/main/java/com/example/delivery/store/domain/entity/StoreEntity.java
@@ -1,7 +1,7 @@
 package com.example.delivery.store.domain.entity;
 
-import com.example.delivery.area.domain.entity.AreaEntity;
-import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.infrastructure.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,35 +10,41 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
 @Getter
-@Table(name = "p_store")
+@Table(
+        name = "p_store",
+        indexes = {
+                @Index(name = "idx_store_owner", columnList = "owner_id"),
+                @Index(name = "idx_store_category", columnList = "category_id"),
+                @Index(name = "idx_store_area", columnList = "area_id"),
+                @Index(name = "idx_store_name", columnList = "name")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreEntity extends BaseEntity {
 
+    private static final BigDecimal DEFAULT_RATING =
+            BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
+    private static final BigDecimal MAX_RATING = new BigDecimal("5.0");
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "store_id",  nullable = false, updatable = false)
+    @Column(name = "store_id", nullable = false, updatable = false)
     private UUID id;
 
-    /**
-     * User 도메인과는 ID만 참조하도록 함
-     */
-    @Column(length = 10, nullable = false)
-    private Long ownerId;
+    @Column(name = "owner_id", nullable = false)
+    private UUID ownerId;
 
-    /**
-     * Category 및 Area 도메인은 Store에서만 사용하므로 엔티티를 참조함
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
-    private CategoryEntity category;
+    @Column(name = "category_id", nullable = false)
+    private UUID categoryId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "area_id", nullable = false)
-    private AreaEntity area;
+    @Column(name = "area_id", nullable = false)
+    private UUID areaId;
 
     @Column(length = 100, nullable = false)
     private String name;
@@ -49,32 +55,69 @@ public class StoreEntity extends BaseEntity {
     @Column(length = 20)
     private String phone;
 
-    @Column(precision = 2, scale = 1, nullable = false)
+    @Column(name = "average_rating", precision = 2, scale = 1, nullable = false)
     private BigDecimal averageRating;
 
-    @Column(nullable = false)
+    @Column(name = "is_hidden", nullable = false)
     private boolean isHidden;
 
     @Builder
-    public StoreEntity(Long ownerId, CategoryEntity category, AreaEntity area, String name, String address, String phone) {
+    private StoreEntity(UUID ownerId, UUID categoryId, UUID areaId, String name, String address, String phone) {
         this.ownerId = ownerId;
-        this.category = category;
-        this.area = area;
+        this.categoryId = categoryId;
+        this.areaId = areaId;
         this.name = name;
         this.address = address;
         this.phone = phone;
-        this.averageRating = BigDecimal.ZERO;
+        this.averageRating = DEFAULT_RATING;
         this.isHidden = false;
     }
 
     /**
-     * 연관관계 메서드
+     * 가게 기본 정보 수정. phone 은 null 허용(미입력 시 null 로 덮어씀)
      */
-    public void updateAverageRating(BigDecimal averageRating) {
-        this.averageRating = averageRating;
+    public void update(UUID categoryId, UUID areaId, String name, String address, String phone) {
+        this.categoryId = categoryId;
+        this.areaId = areaId;
+        this.name = name;
+        this.address = address;
+        this.phone = phone;
     }
 
+    /**
+     * 숨김 토글 (삭제와 독립적으로 동작)
+     */
     public void toggleHidden() {
         this.isHidden = !this.isHidden;
+    }
+
+    /**
+     * 리뷰 CUD 시 평균 평점을 재계산
+     * 도메인 불변식: 0.0 ≤ averageRating ≤ 5.0
+     */
+    public void recalculateAverageRating(List<Integer> ratings) {
+        if (ratings == null || ratings.isEmpty()) {
+            this.averageRating = DEFAULT_RATING;
+            return;
+        }
+
+        double average = ratings.stream()
+                .mapToInt(Integer::intValue)
+                .average()
+                .orElse(0.0);
+
+        BigDecimal rounded = BigDecimal.valueOf(average).setScale(1, RoundingMode.HALF_UP);
+        if (rounded.compareTo(BigDecimal.ZERO) < 0 || rounded.compareTo(MAX_RATING) > 0) {
+            throw new BusinessException(ErrorCode.INVALID_STORE_RATING);
+        }
+
+        this.averageRating = rounded;
+    }
+
+    /**
+     * 본인 가게 여부
+     */
+    public boolean isOwnedBy(UUID ownerId) {
+        return this.ownerId.equals(ownerId);
     }
 }

--- a/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
@@ -1,4 +1,19 @@
 package com.example.delivery.store.domain.repository;
 
+import com.example.delivery.store.domain.entity.StoreEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
 public interface StoreRepository {
+
+    StoreEntity save(StoreEntity store);
+
+    Optional<StoreEntity> findById(UUID storeId);
+
+    Optional<StoreEntity> findByOwnerIdAndName(UUID ownerId, String name);
+
+    Page<StoreEntity> search(String keyword, UUID categoryId, UUID areaId, Pageable pageable);
 }

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
@@ -1,40 +1,14 @@
 package com.example.delivery.store.infrastructure.repository;
 
 import com.example.delivery.store.domain.entity.StoreEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface StoreJpaRepository extends JpaRepository<StoreEntity, UUID> {
+public interface StoreJpaRepository extends JpaRepository<StoreEntity, UUID>, StoreRepositoryCustom {
 
     Optional<StoreEntity> findByIdAndDeletedAtIsNull(UUID id);
 
     Optional<StoreEntity> findByOwnerIdAndNameAndDeletedAtIsNull(UUID ownerId, String name);
-
-    /**
-     * 목록 검색: 삭제·숨김 제외 + 선택적 필터(keyword/categoryId/areaId).
-     * 동적 조건은 파라미터 null 체크로 처리한다.
-     * <p>
-     * PostgreSQL + Hibernate 조합에서 null String 파라미터는 타입 정보가 유실되어
-     * {@code bytea} 로 추정되는 이슈가 있으므로 {@code CAST(:keyword AS string)} 으로 명시한다.
-     */
-    @Query("""
-            SELECT s FROM StoreEntity s
-             WHERE s.deletedAt IS NULL
-               AND s.isHidden = false
-               AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', CAST(:keyword AS string), '%')))
-               AND (:categoryId IS NULL OR s.categoryId = :categoryId)
-               AND (:areaId IS NULL OR s.areaId = :areaId)
-            """)
-    Page<StoreEntity> search(
-            @Param("keyword") String keyword,
-            @Param("categoryId") UUID categoryId,
-            @Param("areaId") UUID areaId,
-            Pageable pageable
-    );
 }

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
@@ -1,7 +1,40 @@
 package com.example.delivery.store.infrastructure.repository;
 
 import com.example.delivery.store.domain.entity.StoreEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface StoreJpaRepository extends JpaRepository<StoreEntity, Long> {
+import java.util.Optional;
+import java.util.UUID;
+
+public interface StoreJpaRepository extends JpaRepository<StoreEntity, UUID> {
+
+    Optional<StoreEntity> findByIdAndDeletedAtIsNull(UUID id);
+
+    Optional<StoreEntity> findByOwnerIdAndNameAndDeletedAtIsNull(UUID ownerId, String name);
+
+    /**
+     * 목록 검색: 삭제·숨김 제외 + 선택적 필터(keyword/categoryId/areaId).
+     * 동적 조건은 파라미터 null 체크로 처리한다.
+     * <p>
+     * PostgreSQL + Hibernate 조합에서 null String 파라미터는 타입 정보가 유실되어
+     * {@code bytea} 로 추정되는 이슈가 있으므로 {@code CAST(:keyword AS string)} 으로 명시한다.
+     */
+    @Query("""
+            SELECT s FROM StoreEntity s
+             WHERE s.deletedAt IS NULL
+               AND s.isHidden = false
+               AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', CAST(:keyword AS string), '%')))
+               AND (:categoryId IS NULL OR s.categoryId = :categoryId)
+               AND (:areaId IS NULL OR s.areaId = :areaId)
+            """)
+    Page<StoreEntity> search(
+            @Param("keyword") String keyword,
+            @Param("categoryId") UUID categoryId,
+            @Param("areaId") UUID areaId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.example.delivery.store.infrastructure.repository;
+
+import com.example.delivery.store.domain.entity.StoreEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+/**
+ * Store 복합 검색 전용 Custom 레포지토리
+ */
+public interface StoreRepositoryCustom {
+
+    Page<StoreEntity> search(String keyword, UUID categoryId, UUID areaId, Pageable pageable);
+}

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustomImpl.java
@@ -1,0 +1,120 @@
+package com.example.delivery.store.infrastructure.repository;
+
+import com.example.delivery.store.domain.entity.QStoreEntity;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
+
+    private static final QStoreEntity STORE = QStoreEntity.storeEntity;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<StoreEntity> search(String keyword, UUID categoryId, UUID areaId, Pageable pageable) {
+
+        BooleanExpression[] conditions = new BooleanExpression[]{
+                notDeleted(),
+                notHidden(),
+                nameContainsIgnoreCase(keyword),
+                categoryIdEq(categoryId),
+                areaIdEq(areaId)
+        };
+
+        List<StoreEntity> content = queryFactory
+                .selectFrom(STORE)
+                .where(conditions)
+                .orderBy(toOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(STORE.count())
+                .from(STORE)
+                .where(conditions)
+                .fetchOne();
+
+        long total = totalCount != null ? totalCount : 0L;
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 조건 조립 (null 이면 조건 자체를 제외)
+     */
+    private BooleanExpression notDeleted() {
+        return STORE.deletedAt.isNull();
+    }
+
+    private BooleanExpression notHidden() {
+        return STORE.isHidden.isFalse();
+    }
+
+    private BooleanExpression nameContainsIgnoreCase(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return null;
+        }
+        return STORE.name.containsIgnoreCase(keyword.trim());
+    }
+
+    private BooleanExpression categoryIdEq(UUID categoryId) {
+        return categoryId == null ? null : STORE.categoryId.eq(categoryId);
+    }
+
+    private BooleanExpression areaIdEq(UUID areaId) {
+        return areaId == null ? null : STORE.areaId.eq(areaId);
+    }
+
+    /**
+     * 정렬
+     * Pageable 의 Sort 를 QueryDSL OrderSpecifier 로 변환
+     * 지원 속성: createdAt, updatedAt, name, averageRating
+     * 지원하지 않는 속성은 무시하고, 결과가 비면 createdAt DESC 를 기본 적용
+     */
+    private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+
+        for (Sort.Order order : sort) {
+            ComparableExpressionBase<?> path = resolvePath(order.getProperty());
+            if (path == null) {
+                continue;
+            }
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            specifiers.add(new OrderSpecifier<>(direction, path));
+        }
+
+        if (specifiers.isEmpty()) {
+            specifiers.add(STORE.createdAt.desc());
+        }
+
+        return specifiers.toArray(new OrderSpecifier[0]);
+    }
+
+    private ComparableExpressionBase<?> resolvePath(String property) {
+        return switch (property) {
+            case "createdAt" -> STORE.createdAt;
+            case "updatedAt" -> STORE.updatedAt;
+            case "name" -> STORE.name;
+            case "averageRating" -> STORE.averageRating;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.example.delivery.store.infrastructure.repository;
+
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreRepositoryImpl implements StoreRepository {
+
+    private final StoreJpaRepository storeJpaRepository;
+
+    @Override
+    public StoreEntity save(StoreEntity store) {
+        return storeJpaRepository.save(store);
+    }
+
+    @Override
+    public Optional<StoreEntity> findById(UUID storeId) {
+        return storeJpaRepository.findByIdAndDeletedAtIsNull(storeId);
+    }
+
+    @Override
+    public Optional<StoreEntity> findByOwnerIdAndName(UUID ownerId, String name) {
+        return storeJpaRepository.findByOwnerIdAndNameAndDeletedAtIsNull(ownerId, name);
+    }
+
+    @Override
+    public Page<StoreEntity> search(String keyword, UUID categoryId, UUID areaId, Pageable pageable) {
+        return storeJpaRepository.search(keyword, categoryId, areaId, pageable);
+    }
+}

--- a/src/main/java/com/example/delivery/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/example/delivery/store/presentation/controller/StoreControllerV1.java
@@ -1,0 +1,79 @@
+package com.example.delivery.store.presentation.controller;
+
+import com.example.delivery.global.common.response.ApiResponse;
+import com.example.delivery.global.common.response.PageResponse;
+import com.example.delivery.global.infrastructure.security.UserPrincipal;
+import com.example.delivery.store.application.service.StoreServiceV1;
+import com.example.delivery.store.presentation.dto.request.ReqCreateStoreDto;
+import com.example.delivery.store.presentation.dto.request.ReqUpdateStoreDto;
+import com.example.delivery.store.presentation.dto.response.ResCreateStoreDto;
+import com.example.delivery.store.presentation.dto.response.ResGetStoreDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/stores")
+@RequiredArgsConstructor
+public class StoreControllerV1 {
+
+    private final StoreServiceV1 storeService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('OWNER')")
+    public ApiResponse<ResCreateStoreDto> createStore(
+            @Valid @RequestBody ReqCreateStoreDto request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return ApiResponse.created(storeService.createStore(request, userPrincipal.id()));
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<ResGetStoreDto>> getAllStores(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) UUID categoryId,
+            @RequestParam(required = false) UUID areaId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.ok(storeService.getAllStores(keyword, categoryId, areaId, page, size));
+    }
+
+    @GetMapping("/{storeId}")
+    public ApiResponse<ResGetStoreDto> getStore(@PathVariable UUID storeId) {
+        return ApiResponse.ok(storeService.getStore(storeId));
+    }
+
+    @PatchMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    public ApiResponse<ResGetStoreDto> updateStore(
+            @PathVariable UUID storeId,
+            @Valid @RequestBody ReqUpdateStoreDto request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return ApiResponse.ok(storeService.updateStore(storeId, request, userPrincipal));
+    }
+
+    @PatchMapping("/{storeId}/hide")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    public ApiResponse<ResGetStoreDto> toggleHiddenStore(
+            @PathVariable UUID storeId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return ApiResponse.ok(storeService.toggleHiddenStore(storeId, userPrincipal));
+    }
+
+    @DeleteMapping("/{storeId}")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ApiResponse<Void> deleteStore(
+            @PathVariable UUID storeId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        storeService.deleteStore(storeId, userPrincipal);
+        return ApiResponse.ok(null);
+    }
+}

--- a/src/main/java/com/example/delivery/store/presentation/dto/request/ReqCreateStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/request/ReqCreateStoreDto.java
@@ -1,0 +1,33 @@
+package com.example.delivery.store.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+public record ReqCreateStoreDto(
+
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        UUID categoryId,
+
+        @NotNull(message = "지역 ID는 필수입니다.")
+        UUID areaId,
+
+        @NotBlank(message = "가게명은 필수입니다.")
+        @Size(max = 100, message = "가게명은 100자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "가게 주소는 필수입니다.")
+        @Size(max = 255, message = "가게 주소는 255자 이하여야 합니다.")
+        String address,
+
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다.")
+        @Pattern(
+                regexp = "^$|^[0-9-]{9,20}$",
+                message = "전화번호 형식이 올바르지 않습니다."
+        )
+        String phone
+) {
+}

--- a/src/main/java/com/example/delivery/store/presentation/dto/request/ReqUpdateStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/request/ReqUpdateStoreDto.java
@@ -1,0 +1,33 @@
+package com.example.delivery.store.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+public record ReqUpdateStoreDto(
+
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        UUID categoryId,
+
+        @NotNull(message = "지역 ID는 필수입니다.")
+        UUID areaId,
+
+        @NotBlank(message = "가게명은 필수입니다.")
+        @Size(max = 100, message = "가게명은 100자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "가게 주소는 필수입니다.")
+        @Size(max = 255, message = "가게 주소는 255자 이하여야 합니다.")
+        String address,
+
+        @Size(max = 20, message = "전화번호는 20자 이하여야 합니다.")
+        @Pattern(
+                regexp = "^$|^[0-9-]{9,20}$",
+                message = "전화번호 형식이 올바르지 않습니다."
+        )
+        String phone
+) {
+}

--- a/src/main/java/com/example/delivery/store/presentation/dto/response/ResCreateStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/response/ResCreateStoreDto.java
@@ -1,0 +1,37 @@
+package com.example.delivery.store.presentation.dto.response;
+
+import com.example.delivery.store.domain.entity.StoreEntity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ResCreateStoreDto(
+        UUID storeId,
+        UUID ownerId,
+        UUID categoryId,
+        UUID areaId,
+        String name,
+        String address,
+        String phone,
+        BigDecimal averageRating,
+        boolean isHidden,
+        LocalDateTime createdAt,
+        String createdBy
+) {
+    public static ResCreateStoreDto from(StoreEntity store) {
+        return new ResCreateStoreDto(
+                store.getId(),
+                store.getOwnerId(),
+                store.getCategoryId(),
+                store.getAreaId(),
+                store.getName(),
+                store.getAddress(),
+                store.getPhone(),
+                store.getAverageRating(),
+                store.isHidden(),
+                store.getCreatedAt(),
+                store.getCreatedBy()
+        );
+    }
+}

--- a/src/main/java/com/example/delivery/store/presentation/dto/response/ResGetStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/response/ResGetStoreDto.java
@@ -1,0 +1,41 @@
+package com.example.delivery.store.presentation.dto.response;
+
+import com.example.delivery.store.domain.entity.StoreEntity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ResGetStoreDto(
+        UUID storeId,
+        UUID ownerId,
+        UUID categoryId,
+        UUID areaId,
+        String name,
+        String address,
+        String phone,
+        BigDecimal averageRating,
+        boolean isHidden,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy
+) {
+    public static ResGetStoreDto from(StoreEntity store) {
+        return new ResGetStoreDto(
+                store.getId(),
+                store.getOwnerId(),
+                store.getCategoryId(),
+                store.getAreaId(),
+                store.getName(),
+                store.getAddress(),
+                store.getPhone(),
+                store.getAverageRating(),
+                store.isHidden(),
+                store.getCreatedAt(),
+                store.getCreatedBy(),
+                store.getUpdatedAt(),
+                store.getUpdatedBy()
+        );
+    }
+}

--- a/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
+++ b/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
@@ -1,0 +1,847 @@
+package com.example.delivery.store.application.service;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+import com.example.delivery.global.common.response.PageResponse;
+import com.example.delivery.global.infrastructure.security.UserPrincipal;
+import com.example.delivery.store.application.exception.RelatedAreaNotFoundException;
+import com.example.delivery.store.application.exception.RelatedCategoryNotFoundException;
+import com.example.delivery.store.application.exception.StoreAccessDeniedException;
+import com.example.delivery.store.application.exception.StoreNotFoundException;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import com.example.delivery.store.presentation.dto.request.ReqCreateStoreDto;
+import com.example.delivery.store.presentation.dto.request.ReqUpdateStoreDto;
+import com.example.delivery.store.presentation.dto.response.ResCreateStoreDto;
+import com.example.delivery.store.presentation.dto.response.ResGetStoreDto;
+import com.example.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceV1Test {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private AreaRepository areaRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private StoreServiceV1 storeService;
+
+    @Nested
+    @DisplayName("가게 등록 테스트")
+    class CreateStoreTest {
+
+        @Test
+        @DisplayName("가게 등록 성공")
+        void createStore_success() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            ReqCreateStoreDto request = new ReqCreateStoreDto(
+                    categoryId, areaId, "광화문 한식당", "서울 종로구 세종대로 1", "02-1234-5678"
+            );
+
+            StoreEntity saved = createStoreEntity(
+                    ownerId, categoryId, areaId, "광화문 한식당", "서울 종로구 세종대로 1", "02-1234-5678"
+            );
+
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(createAreaEntity(areaId)));
+            given(storeRepository.findByOwnerIdAndName(ownerId, "광화문 한식당")).willReturn(Optional.empty());
+            given(storeRepository.save(any(StoreEntity.class))).willReturn(saved);
+
+            // when
+            ResCreateStoreDto result = storeService.createStore(request, ownerId);
+
+            // then
+            assertThat(result.storeId()).isEqualTo(saved.getId());
+            assertThat(result.ownerId()).isEqualTo(ownerId);
+            assertThat(result.categoryId()).isEqualTo(categoryId);
+            assertThat(result.areaId()).isEqualTo(areaId);
+            assertThat(result.name()).isEqualTo("광화문 한식당");
+            assertThat(result.isHidden()).isFalse();
+
+            ArgumentCaptor<StoreEntity> captor = ArgumentCaptor.forClass(StoreEntity.class);
+            verify(storeRepository).save(captor.capture());
+
+            StoreEntity captured = captor.getValue();
+            assertThat(captured.getOwnerId()).isEqualTo(ownerId);
+            assertThat(captured.getName()).isEqualTo("광화문 한식당");
+            assertThat(captured.getAddress()).isEqualTo("서울 종로구 세종대로 1");
+            assertThat(captured.getPhone()).isEqualTo("02-1234-5678");
+        }
+
+        @Test
+        @DisplayName("이름/주소 공백은 trim 되고 빈 phone 은 null 로 저장")
+        void createStore_success_trimsAndNormalizesPhone() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            ReqCreateStoreDto request = new ReqCreateStoreDto(
+                    categoryId, areaId, "  광화문 한식당  ", "  서울 종로구  ", "   "
+            );
+
+            StoreEntity saved = createStoreEntity(
+                    ownerId, categoryId, areaId, "광화문 한식당", "서울 종로구", null
+            );
+
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(createAreaEntity(areaId)));
+            given(storeRepository.findByOwnerIdAndName(ownerId, "광화문 한식당")).willReturn(Optional.empty());
+            given(storeRepository.save(any(StoreEntity.class))).willReturn(saved);
+
+            // when
+            storeService.createStore(request, ownerId);
+
+            // then
+            ArgumentCaptor<StoreEntity> captor = ArgumentCaptor.forClass(StoreEntity.class);
+            verify(storeRepository).save(captor.capture());
+
+            StoreEntity captured = captor.getValue();
+            assertThat(captured.getName()).isEqualTo("광화문 한식당");
+            assertThat(captured.getAddress()).isEqualTo("서울 종로구");
+            assertThat(captured.getPhone()).isNull();
+        }
+
+        @Test
+        @DisplayName("카테고리가 존재하지 않으면 실패")
+        void createStore_fail_categoryNotFound() {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            ReqCreateStoreDto request = new ReqCreateStoreDto(
+                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678"
+            );
+
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(request, ownerId))
+                    .isInstanceOf(RelatedCategoryNotFoundException.class);
+
+            verify(storeRepository, never()).save(any(StoreEntity.class));
+        }
+
+        @Test
+        @DisplayName("지역이 존재하지 않으면 실패")
+        void createStore_fail_areaNotFound() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            ReqCreateStoreDto request = new ReqCreateStoreDto(
+                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678"
+            );
+
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(request, ownerId))
+                    .isInstanceOf(RelatedAreaNotFoundException.class);
+
+            verify(storeRepository, never()).save(any(StoreEntity.class));
+        }
+
+        @Test
+        @DisplayName("동일 소유자의 동일 이름 중복 시 실패")
+        void createStore_fail_duplicateName() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            ReqCreateStoreDto request = new ReqCreateStoreDto(
+                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678"
+            );
+
+            StoreEntity existing = createStoreEntity(
+                    ownerId, categoryId, areaId, "광화문 한식당", "서울", null
+            );
+
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(createAreaEntity(areaId)));
+            given(storeRepository.findByOwnerIdAndName(ownerId, "광화문 한식당")).willReturn(Optional.of(existing));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.createStore(request, ownerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STORE_ALREADY_EXISTS);
+
+            verify(storeRepository, never()).save(any(StoreEntity.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 목록 조회 테스트")
+    class GetAllStoresTest {
+
+        @Test
+        @DisplayName("필터 없이 전체 가게 목록 조회 성공")
+        void getAllStores_success_noFilter() throws Exception {
+            // given
+            StoreEntity store1 = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null
+            );
+            StoreEntity store2 = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "가게B", "서울", null
+            );
+
+            Page<StoreEntity> page = new PageImpl<>(
+                    List.of(store1, store2),
+                    PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt")),
+                    2
+            );
+
+            given(storeRepository.search(eq(null), eq(null), eq(null), any(Pageable.class))).willReturn(page);
+
+            // when
+            PageResponse<ResGetStoreDto> result = storeService.getAllStores(null, null, null, 0, 10);
+
+            // then
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.content().get(0).name()).isEqualTo("가게A");
+            assertThat(result.content().get(1).name()).isEqualTo("가게B");
+            assertThat(result.page()).isEqualTo(0);
+            assertThat(result.size()).isEqualTo(10);
+            assertThat(result.totalElements()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("키워드 공백은 null 로 정규화되어 전체 조회")
+        void getAllStores_blankKeyword_normalizedToNull() {
+            // given
+            Page<StoreEntity> empty = new PageImpl<>(
+                    List.of(),
+                    PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt")),
+                    0
+            );
+
+            given(storeRepository.search(any(), any(), any(), any(Pageable.class))).willReturn(empty);
+
+            // when
+            storeService.getAllStores("   ", null, null, 0, 10);
+
+            // then
+            ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+            verify(storeRepository).search(keywordCaptor.capture(), eq(null), eq(null), any(Pageable.class));
+
+            assertThat(keywordCaptor.getValue()).isNull();
+        }
+
+        @Test
+        @DisplayName("키워드/카테고리/지역 필터 적용 조회 성공")
+        void getAllStores_withAllFilters() throws Exception {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), categoryId, areaId, "광화문 한식당", "서울", null
+            );
+
+            Page<StoreEntity> page = new PageImpl<>(
+                    List.of(store),
+                    PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt")),
+                    1
+            );
+
+            given(storeRepository.search(eq("광화문"), eq(categoryId), eq(areaId), any(Pageable.class))).willReturn(page);
+
+            // when
+            PageResponse<ResGetStoreDto> result = storeService.getAllStores(
+                    "  광화문  ", categoryId, areaId, 0, 10
+            );
+
+            // then
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).name()).isEqualTo("광화문 한식당");
+
+            ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+            verify(storeRepository).search(keywordCaptor.capture(), eq(categoryId), eq(areaId), any(Pageable.class));
+
+            assertThat(keywordCaptor.getValue()).isEqualTo("광화문");
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 상세 조회 테스트")
+    class GetStoreTest {
+
+        @Test
+        @DisplayName("가게 상세 조회 성공")
+        void getStore_success() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "광화문 한식당", "서울", "02-1234-5678"
+            );
+            setField(store, "id", storeId);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when
+            ResGetStoreDto result = storeService.getStore(storeId);
+
+            // then
+            assertThat(result.storeId()).isEqualTo(storeId);
+            assertThat(result.name()).isEqualTo("광화문 한식당");
+            assertThat(result.phone()).isEqualTo("02-1234-5678");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가게는 조회 실패")
+        void getStore_fail_notFound() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            given(storeRepository.findById(storeId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.getStore(storeId))
+                    .isInstanceOf(StoreNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 수정 테스트")
+    class UpdateStoreTest {
+
+        @Test
+        @DisplayName("본인 OWNER 가 자신의 가게를 수정 성공")
+        void updateStore_success_ownerSelf() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            StoreEntity store = createStoreEntity(
+                    ownerId, categoryId, areaId, "광화문 한식당", "서울", "02-1111-1111"
+            );
+            setField(store, "id", storeId);
+
+            ReqUpdateStoreDto request = new ReqUpdateStoreDto(
+                    categoryId, areaId, "광화문 리뉴얼", "서울 종로구 2", "02-2222-2222"
+            );
+            UserPrincipal principal = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(createAreaEntity(areaId)));
+            given(storeRepository.findByOwnerIdAndName(ownerId, "광화문 리뉴얼")).willReturn(Optional.empty());
+
+            // when
+            ResGetStoreDto result = storeService.updateStore(storeId, request, principal);
+
+            // then
+            assertThat(result.name()).isEqualTo("광화문 리뉴얼");
+            assertThat(store.getName()).isEqualTo("광화문 리뉴얼");
+            assertThat(store.getAddress()).isEqualTo("서울 종로구 2");
+            assertThat(store.getPhone()).isEqualTo("02-2222-2222");
+        }
+
+        @Test
+        @DisplayName("MANAGER 는 타인 가게도 수정 가능")
+        void updateStore_success_manager() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            StoreEntity store = createStoreEntity(
+                    ownerId, categoryId, areaId, "원래이름", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            ReqUpdateStoreDto request = new ReqUpdateStoreDto(
+                    categoryId, areaId, "새이름", "서울", null
+            );
+            UserPrincipal manager = new UserPrincipal(UUID.randomUUID(), "mng01", UserRole.MANAGER);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(createAreaEntity(areaId)));
+            given(storeRepository.findByOwnerIdAndName(ownerId, "새이름")).willReturn(Optional.empty());
+
+            // when
+            ResGetStoreDto result = storeService.updateStore(storeId, request, manager);
+
+            // then
+            assertThat(result.name()).isEqualTo("새이름");
+        }
+
+        @Test
+        @DisplayName("이름이 바뀌지 않은 경우 중복 검증은 생략")
+        void updateStore_skipDuplicateCheck_whenNameUnchanged() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            StoreEntity store = createStoreEntity(
+                    ownerId, categoryId, areaId, "광화문 한식당", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            ReqUpdateStoreDto request = new ReqUpdateStoreDto(
+                    categoryId, areaId, "광화문 한식당", "서울 바뀐 주소", "02-9999-9999"
+            );
+            UserPrincipal principal = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(createAreaEntity(areaId)));
+
+            // when
+            storeService.updateStore(storeId, request, principal);
+
+            // then
+            verify(storeRepository, never()).findByOwnerIdAndName(any(UUID.class), any(String.class));
+            assertThat(store.getAddress()).isEqualTo("서울 바뀐 주소");
+        }
+
+        @Test
+        @DisplayName("타인 OWNER 가 남의 가게 수정 시 실패")
+        void updateStore_fail_otherOwner() throws Exception {
+            // given
+            UUID realOwnerId = UUID.randomUUID();
+            UUID otherOwnerId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+
+            StoreEntity store = createStoreEntity(
+                    realOwnerId, UUID.randomUUID(), UUID.randomUUID(), "광화문 한식당", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            ReqUpdateStoreDto request = new ReqUpdateStoreDto(
+                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null
+            );
+            UserPrincipal other = new UserPrincipal(otherOwnerId, "other01", UserRole.OWNER);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.updateStore(storeId, request, other))
+                    .isInstanceOf(StoreAccessDeniedException.class);
+
+            verify(categoryRepository, never()).findById(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 는 가게 수정 불가")
+        void updateStore_fail_customer() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "광화문 한식당", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            ReqUpdateStoreDto request = new ReqUpdateStoreDto(
+                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null
+            );
+            UserPrincipal customer = new UserPrincipal(UUID.randomUUID(), "cust01", UserRole.CUSTOMER);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.updateStore(storeId, request, customer))
+                    .isInstanceOf(StoreAccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가게 수정 시 실패")
+        void updateStore_fail_notFound() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            ReqUpdateStoreDto request = new ReqUpdateStoreDto(
+                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null
+            );
+            UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "owner01", UserRole.OWNER);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.updateStore(storeId, request, principal))
+                    .isInstanceOf(StoreNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("이름 변경 시 동일 소유자 내 중복이면 실패")
+        void updateStore_fail_duplicateNameAfterRename() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            UUID categoryId = UUID.randomUUID();
+            UUID areaId = UUID.randomUUID();
+
+            StoreEntity store = createStoreEntity(
+                    ownerId, categoryId, areaId, "원래이름", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            StoreEntity duplicated = createStoreEntity(
+                    ownerId, categoryId, areaId, "새이름", "서울", null
+            );
+
+            ReqUpdateStoreDto request = new ReqUpdateStoreDto(
+                    categoryId, areaId, "새이름", "서울", null
+            );
+            UserPrincipal principal = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
+
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+            given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
+            given(areaRepository.findById(areaId)).willReturn(Optional.of(createAreaEntity(areaId)));
+            given(storeRepository.findByOwnerIdAndName(ownerId, "새이름")).willReturn(Optional.of(duplicated));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.updateStore(storeId, request, principal))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.STORE_ALREADY_EXISTS);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 숨김 토글 테스트")
+    class ToggleHiddenStoreTest {
+
+        @Test
+        @DisplayName("본인 OWNER 는 숨김 토글 가능")
+        void toggleHiddenStore_success_ownerSelf() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    ownerId, UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            UserPrincipal owner = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when
+            ResGetStoreDto result = storeService.toggleHiddenStore(storeId, owner);
+
+            // then
+            assertThat(result.isHidden()).isTrue();
+            assertThat(store.isHidden()).isTrue();
+        }
+
+        @Test
+        @DisplayName("MASTER 는 타인 가게도 숨김 토글 가능")
+        void toggleHiddenStore_success_master() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            UserPrincipal master = new UserPrincipal(UUID.randomUUID(), "mst01", UserRole.MASTER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when
+            storeService.toggleHiddenStore(storeId, master);
+
+            // then
+            assertThat(store.isHidden()).isTrue();
+        }
+
+        @Test
+        @DisplayName("타인 OWNER 가 남의 가게 숨김 시도 시 실패")
+        void toggleHiddenStore_fail_otherOwner() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            UserPrincipal other = new UserPrincipal(UUID.randomUUID(), "other01", UserRole.OWNER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.toggleHiddenStore(storeId, other))
+                    .isInstanceOf(StoreAccessDeniedException.class);
+
+            assertThat(store.isHidden()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가게 숨김 토글 시 실패")
+        void toggleHiddenStore_fail_notFound() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            UserPrincipal master = new UserPrincipal(UUID.randomUUID(), "mst01", UserRole.MASTER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.toggleHiddenStore(storeId, master))
+                    .isInstanceOf(StoreNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("가게 삭제 테스트")
+    class DeleteStoreTest {
+
+        @Test
+        @DisplayName("본인 OWNER 는 자신의 가게 삭제 성공")
+        void deleteStore_success_ownerSelf() throws Exception {
+            // given
+            UUID ownerId = UUID.randomUUID();
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    ownerId, UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            UserPrincipal owner = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when
+            storeService.deleteStore(storeId, owner);
+
+            // then
+            assertThat(store.isDeleted()).isTrue();
+            assertThat(getField(store)).isEqualTo("owner01");
+        }
+
+        @Test
+        @DisplayName("MASTER 는 타인 가게 삭제 성공")
+        void deleteStore_success_master() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null);
+            setField(store, "id", storeId);
+
+            UserPrincipal master = new UserPrincipal(UUID.randomUUID(), "mst01", UserRole.MASTER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when
+            storeService.deleteStore(storeId, master);
+
+            // then
+            assertThat(store.isDeleted()).isTrue();
+            assertThat(getField(store)).isEqualTo("mst01");
+        }
+
+        @Test
+        @DisplayName("MANAGER 는 가게 삭제 불가")
+        void deleteStore_fail_manager() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            UserPrincipal manager = new UserPrincipal(UUID.randomUUID(), "mng01", UserRole.MANAGER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.deleteStore(storeId, manager))
+                    .isInstanceOf(StoreAccessDeniedException.class);
+
+            assertThat(store.isDeleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("타인 OWNER 는 남의 가게 삭제 불가")
+        void deleteStore_fail_otherOwner() throws Exception {
+            // given
+            UUID storeId = UUID.randomUUID();
+            StoreEntity store = createStoreEntity(
+                    UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "가게A", "서울", null
+            );
+            setField(store, "id", storeId);
+
+            UserPrincipal other = new UserPrincipal(UUID.randomUUID(), "other01", UserRole.OWNER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+            // when & then
+            assertThatThrownBy(() -> storeService.deleteStore(storeId, other))
+                    .isInstanceOf(StoreAccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가게 삭제 시 실패")
+        void deleteStore_fail_notFound() {
+            // given
+            UUID storeId = UUID.randomUUID();
+            UserPrincipal master = new UserPrincipal(UUID.randomUUID(), "mst01", UserRole.MASTER);
+            given(storeRepository.findById(storeId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeService.deleteStore(storeId, master))
+                    .isInstanceOf(StoreNotFoundException.class);
+        }
+    }
+
+    /**
+     * Store 데이터 생성 메서드
+     */
+    private StoreEntity createStoreEntity(
+            UUID ownerId, UUID categoryId, UUID areaId,
+            String name, String address, String phone
+    ) throws Exception {
+        StoreEntity store = StoreEntity.builder()
+                .ownerId(ownerId)
+                .categoryId(categoryId)
+                .areaId(areaId)
+                .name(name)
+                .address(address)
+                .phone(phone)
+                .build();
+
+        setField(store, "id", UUID.randomUUID());
+        setBaseEntityFields(
+                store,
+                LocalDateTime.of(2026, 1, 1, 12, 0),
+                "owner01",
+                LocalDateTime.of(2026, 1, 1, 12, 0),
+                "owner01"
+        );
+
+        return store;
+    }
+
+    /**
+     * Category 데이터 생성 메서드
+     */
+    private CategoryEntity createCategoryEntity(UUID categoryId) throws Exception {
+        CategoryEntity category = CategoryEntity.builder()
+                .name("한식")
+                .build();
+
+        setField(category, "id", categoryId);
+        setBaseEntityFields(
+                category,
+                LocalDateTime.of(2026, 1, 1, 12, 0),
+                "manager01",
+                LocalDateTime.of(2026, 1, 1, 12, 0),
+                "manager01"
+        );
+
+        return category;
+    }
+
+    /**
+     * Area 데이터 생성 메서드
+     */
+    private AreaEntity createAreaEntity(UUID areaId) throws Exception {
+        AreaEntity area = AreaEntity.builder()
+                .name("광화문")
+                .city("서울특별시")
+                .district("종로구")
+                .isActive(true)
+                .build();
+
+        setField(area, "id", areaId);
+        setBaseEntityFields(
+                area,
+                LocalDateTime.of(2026, 1, 1, 12, 0),
+                "manager01",
+                LocalDateTime.of(2026, 1, 1, 12, 0),
+                "manager01"
+        );
+
+        return area;
+    }
+
+    /**
+     * BaseEntity 기본 설정 메서드
+     */
+    private void setBaseEntityFields(
+            Object target,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime updatedAt,
+            String updatedBy
+    ) throws Exception {
+        setField(target, "createdAt", createdAt);
+        setField(target, "createdBy", createdBy);
+        setField(target, "updatedAt", updatedAt);
+        setField(target, "updatedBy", updatedBy);
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+
+        throw new NoSuchFieldException(fieldName);
+    }
+
+    private Object getField(Object target) throws Exception {
+        Class<?> clazz = target.getClass();
+
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField("deletedBy");
+                field.setAccessible(true);
+                return field.get(target);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+
+        throw new NoSuchFieldException("deletedBy");
+    }
+}


### PR DESCRIPTION
## 개요

Store(가게) 도메인의 CRUD API 전체와 복합 조건 기반 목록 검색 기능을 구현했습니다.
기본 카테고리 초기화, QueryDSL 기반 동적 검색, 서비스 계층 단위 테스트까지 함께 포함됩니다.

## 관련 이슈

- Close #27 

## 구현 내역

### 1. Store CRUD API

`StoreControllerV1` 에 아래 엔드포인트를 구현했습니다.

| Method | Path | 권한 | 설명 |
|---|---|---|---|
| POST | `/api/v1/stores` | OWNER | 가게 등록 (동일 소유자 내 이름 중복 금지) |
| GET | `/api/v1/stores` | ALL | 목록 조회 (키워드/카테고리/지역 복합 필터 + 페이지네이션) |
| GET | `/api/v1/stores/{storeId}` | ALL | 상세 조회 |
| PATCH | `/api/v1/stores/{storeId}` | OWNER(본인) / MANAGER / MASTER | 가게 정보 수정 |
| PATCH | `/api/v1/stores/{storeId}/hide` | OWNER(본인) / MANAGER / MASTER | 노출 여부 토글 |
| DELETE | `/api/v1/stores/{storeId}` | OWNER(본인) / MASTER | 소프트 삭제 |

권한 검증 방식
- 브로드한 Role 체크: `@PreAuthorize`
- 세밀한 소유권 체크: 서비스 계층의 `StoreEntity#isOwnedBy` 호출
- DELETE 는 MANAGER 제외 (정책상 관리자는 삭제 불가)

도메인 규칙
- 이름/주소/전화번호 공백 정규화(`trim`), 전화번호는 미입력 시 null 보존
- `averageRating` 기본값 `0.0`, 범위 `[0.0, 5.0]` 불변식 (`recalculateAverageRating` 도메인 메서드 제공)
- 소프트 삭제 시 `deletedAt` / `deletedBy` 기록

연관 엔티티 존재 검증
- `categoryId` / `areaId` 는 Create/Update 시점에 각각 존재 여부 검증 (`RelatedCategoryNotFoundException`, `RelatedAreaNotFoundException`)

### 2. 기본 카테고리 초기화

`CategoryDataInitializer` (ApplicationRunner) 추가.
애플리케이션 기동 시 **한식/중식/분식/치킨/피자** 5종을 기본 삽입하며,
이미 존재하면 스킵되는 idempotent 구조 (`ddl-auto: update` 재기동에도 안전).
`@Profile("!test")` 로 테스트 컨텍스트에서는 비활성화.

### 3. 가게 검색 QueryDSL 전환

초기엔 JPQL `@Query` 로 구현했으나, 도전 과제에 맞게 **QueryDSL 기반 동적 검색**으로 재구성했습니다.

- `build.gradle`: `querydsl-jpa:5.0.0:jakarta`, `querydsl-apt:5.0.0:jakarta` 의존성 추가
- Q클래스 생성 경로 `/src/main/generated` 설정 (`.gitignore` 기존 규칙과 정합)
- `QuerydslConfig`: `JPAQueryFactory` Bean 등록
- `StoreRepositoryCustom` / `StoreRepositoryCustomImpl` (신규)
  - `keyword` / `categoryId` / `areaId` 각각 null-tolerant 조건 조립 (`BooleanExpression` 반환이 null 이면 `where(...)` 에서 자동 제외)
  - `Pageable` 의 Sort → `OrderSpecifier` 변환 (createdAt/updatedAt/name/averageRating 허용 목록 방식)
  - count 쿼리 분리 실행
- `StoreJpaRepository`: 기존 `@Query` 제거, `StoreRepositoryCustom` 조합

검색 동작 매트릭스

| 입력 | 동작 |
|---|---|
| (없음) | 삭제/숨김 제외한 전체 목록 |
| `categoryId` 만 | 해당 카테고리 소속 가게만 |
| `categoryId` + `keyword` | 해당 카테고리 + 이름 부분 일치 (대소문자 무시) |
| `areaId` 추가 | AND 로 결합되어 함께 필터링 |

### 4. 단위 테스트

`StoreServiceV1Test` 를 JUnit 5 + Mockito + AssertJ + BDDMockito 조합으로 작성했습니다.
6개의 `@Nested` 그룹으로 서비스 메서드별 구획화:

- `CreateStoreTest` — 성공 / 전화번호 trim·null / 카테고리·지역 미존재 / 이름 중복
- `GetAllStoresTest` — 필터 없음 / 공백 키워드 정규화 / 전체 필터
- `GetStoreTest` — 성공 / 미존재
- `UpdateStoreTest` — OWNER 본인 / MANAGER / 같은 이름 중복체크 스킵 / 타 OWNER 거부 / CUSTOMER 거부 / 미존재 / 개명 후 중복
- `ToggleHiddenStoreTest` — OWNER 본인 / MASTER / 타 OWNER 거부 / 미존재
- `DeleteStoreTest` — OWNER 본인 / MASTER / MANAGER 거부 / 타 OWNER 거부 / 미존재

`BaseEntity` 의 감사 필드 및 `StoreEntity#id` 는 Reflection 헬퍼(`setField` / `setBaseEntityFields`) 로 주입.

QueryDSL 전환은 도메인 포트(`StoreRepository#search`) 시그니처를 유지했기 때문에
Mock 기반 서비스 단위 테스트는 무변경으로 전량 통과합니다.


## Postman 테스트

[Postman Store API doc. 바로가기](https://documenter.getpostman.com/view/39868235/2sBXqFPPBD)

1. OWNER 계정 생성 → 로그인 → 토큰 발급
2. 카테고리 목록 조회로 기본 카테고리 ID 확보, MASTER 로 지역 생성
3. 가게 4건 생성 (한식 2건 / 중식 2건, 이름에 "광화문" 공통 포함 2건)
4. 검색 시나리오 검증
   - 필터 없음 → 4건 전체
   - 카테고리(한식) 만 → 2건
   - 카테고리(한식) + 키워드("광화문") → 1건
