### PR TITLE
feature: review 타 도메인order user store 의존성 주입 및 todo 해결 (#29)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/delivery/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/delivery/review/application/service/ReviewService.java
@@ -37,10 +37,9 @@ public class ReviewService {
             throw new BusinessException(ErrorCode.ORDER_NOT_COMPLETED);
         }
 
-        // TODO: [Order 구현 이후] 본인 주문 여부 검증
-        // if (!order.getCustomerId().equals(principal.username())) {
-        //     throw new BusinessException(ErrorCode.FORBIDDEN);
-        // }
+        if (!order.getCustomerId().equals(principal.username())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
 
         // 1주문 1리뷰 중복 검증
         if (reviewRepository.existsByOrderId(orderId)) {

--- a/src/main/java/com/example/delivery/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/delivery/review/application/service/ReviewService.java
@@ -46,9 +46,7 @@ public class ReviewService {
             throw new BusinessException(ErrorCode.DUPLICATE_REVIEW);
         }
 
-        // TODO: [Order 구현 이후] storeId는 Order 엔티티에서 추출
-        // UUID storeId = order.getStoreId();
-        UUID storeId = request.storeId();
+        UUID storeId = order.getStoreId();
 
         ReviewEntity review = ReviewEntity.builder()
                 .orderId(orderId)

--- a/src/main/java/com/example/delivery/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/delivery/review/application/service/ReviewService.java
@@ -4,6 +4,7 @@ import com.example.delivery.global.common.exception.BusinessException;
 import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.infrastructure.security.UserPrincipal;
 import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.domain.entity.OrderStatus;
 import com.example.delivery.order.infrastructure.repository.OrderRepository;
 import com.example.delivery.review.domain.entity.ReviewEntity;
 import com.example.delivery.review.domain.repository.ReviewRepository;
@@ -32,10 +33,9 @@ public class ReviewService {
         OrderEntity order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
-        // TODO: [Order 구현 이후] 주문 완료 상태 검증
-        // if (order.getStatus() != OrderStatus.COMPLETED) {
-        //     throw new BusinessException(ErrorCode.ORDER_NOT_COMPLETED);
-        // }
+        if (order.getStatus() != OrderStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.ORDER_NOT_COMPLETED);
+        }
 
         // TODO: [Order 구현 이후] 본인 주문 여부 검증
         // if (!order.getCustomerId().equals(principal.username())) {

--- a/src/main/java/com/example/delivery/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/delivery/review/application/service/ReviewService.java
@@ -12,9 +12,11 @@ import com.example.delivery.review.presentation.dto.request.ReqCreateReviewDto;
 import com.example.delivery.review.presentation.dto.request.ReqUpdateReviewDto;
 import com.example.delivery.review.presentation.dto.response.ResReviewDto;
 import com.example.delivery.user.domain.entity.UserRole;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,10 +67,15 @@ public class ReviewService {
         return ResReviewDto.from(saved, "임시 가게명", "임시 닉네임");
     }
 
+    private static final List<Integer> ALLOWED_PAGE_SIZES = List.of(10, 30, 50);
+
     public Page<ResReviewDto> getReviewsByStore(UUID storeId, Integer rating, Pageable pageable) {
+        int size = ALLOWED_PAGE_SIZES.contains(pageable.getPageSize()) ? pageable.getPageSize() : 10;
+        Pageable validatedPageable = PageRequest.of(pageable.getPageNumber(), size, pageable.getSort());
+
         Page<ReviewEntity> reviews = (rating != null)
-                ? reviewRepository.findByStoreIdAndRating(storeId, rating, pageable)
-                : reviewRepository.findByStoreId(storeId, pageable);
+                ? reviewRepository.findByStoreIdAndRating(storeId, rating, validatedPageable)
+                : reviewRepository.findByStoreId(storeId, validatedPageable);
 
         // TODO: [Store/User 구현 이후] 실제 storeName, customerNickname 조회
         return reviews.map(r -> ResReviewDto.from(r, "임시 가게명", "임시 닉네임"));

--- a/src/main/java/com/example/delivery/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/delivery/review/application/service/ReviewService.java
@@ -3,6 +3,8 @@ package com.example.delivery.review.application.service;
 import com.example.delivery.global.common.exception.BusinessException;
 import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.infrastructure.security.UserPrincipal;
+import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.infrastructure.repository.OrderRepository;
 import com.example.delivery.review.domain.entity.ReviewEntity;
 import com.example.delivery.review.domain.repository.ReviewRepository;
 import com.example.delivery.review.presentation.dto.request.ReqCreateReviewDto;
@@ -22,13 +24,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final OrderRepository orderRepository;
 
     @Transactional
     public ResReviewDto createReview(UUID orderId, ReqCreateReviewDto request, UserPrincipal principal) {
 
-        // TODO: [Order 구현 이후] orderId로 Order 조회
-        // OrderEntity order = orderRepository.findById(orderId)
-        //         .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+        OrderEntity order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         // TODO: [Order 구현 이후] 주문 완료 상태 검증
         // if (order.getStatus() != OrderStatus.COMPLETED) {

--- a/src/main/java/com/example/delivery/review/presentation/dto/request/ReqCreateReviewDto.java
+++ b/src/main/java/com/example/delivery/review/presentation/dto/request/ReqCreateReviewDto.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.UUID;
 
 public record ReqCreateReviewDto(
         @NotNull(message = "평점은 필수 입력 항목입니다.")
@@ -12,9 +11,5 @@ public record ReqCreateReviewDto(
         Integer rating,
 
         @Size(max = 200, message = "리뷰 내용은 200자 이내로 작성해주세요.")
-        String content,
-
-        // TODO: [Order 구현 후 제거] storeId는 orderId로 Order 조회 후 추출
-        @NotNull(message = "가게 ID는 필수 입력 항목입니다.")
-        UUID storeId
+        String content
 ) {}

--- a/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
@@ -12,6 +12,7 @@ import com.example.delivery.global.common.exception.BusinessException;
 import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.infrastructure.security.UserPrincipal;
 import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.domain.entity.OrderStatus;
 import com.example.delivery.order.infrastructure.repository.OrderRepository;
 import com.example.delivery.review.domain.entity.ReviewEntity;
 import com.example.delivery.review.domain.repository.ReviewRepository;
@@ -35,7 +36,6 @@ class ReviewServiceTest {
 
     @InjectMocks ReviewService reviewService;
 
-    // ─── 공통 픽스처 ───────────────────────────────────────────────
     private static final UUID ORDER_ID = UUID.randomUUID();
     private static final UUID STORE_ID = UUID.randomUUID();
 
@@ -46,7 +46,6 @@ class ReviewServiceTest {
         return new ReqCreateReviewDto(5, "맛있었어요!", STORE_ID);
     }
 
-    // ─── createReview ──────────────────────────────────────────────
     @Nested
     @DisplayName("createReview — 리뷰 생성")
     class CreateReview {
@@ -68,11 +67,30 @@ class ReviewServiceTest {
         }
 
         @Test
+        @DisplayName("주문 상태가 COMPLETED 아님 → ORDER_NOT_COMPLETED 예외")
+        void orderNotCompleted_throwsException() {
+            // given
+            OrderEntity order = mock(OrderEntity.class);
+            given(order.getStatus()).willReturn(OrderStatus.DELIVERED);
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(order));
+
+            // when / then
+            assertThatThrownBy(() -> reviewService.createReview(ORDER_ID, validRequest(), principal))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ORDER_NOT_COMPLETED));
+
+            verify(reviewRepository, never()).existsByOrderId(any());
+            verify(reviewRepository, never()).save(any());
+        }
+
+        @Test
         @DisplayName("존재하는 orderId, 중복 리뷰 → DUPLICATE_REVIEW 예외")
         void duplicateReview_throwsException() {
             // given
-            given(orderRepository.findById(ORDER_ID))
-                    .willReturn(Optional.of(mock(OrderEntity.class)));
+            OrderEntity order = mock(OrderEntity.class);
+            given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(order));
             given(reviewRepository.existsByOrderId(ORDER_ID)).willReturn(true);
 
             // when / then
@@ -88,6 +106,9 @@ class ReviewServiceTest {
         @DisplayName("존재하는 orderId, 중복 없음 → 리뷰 저장")
         void success_reviewSaved() {
             // given
+            OrderEntity order = mock(OrderEntity.class);
+            given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
+
             ReviewEntity savedReview = ReviewEntity.builder()
                     .orderId(ORDER_ID)
                     .storeId(STORE_ID)
@@ -96,8 +117,7 @@ class ReviewServiceTest {
                     .content("맛있었어요!")
                     .build();
 
-            given(orderRepository.findById(ORDER_ID))
-                    .willReturn(Optional.of(mock(OrderEntity.class)));
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(order));
             given(reviewRepository.existsByOrderId(ORDER_ID)).willReturn(false);
             given(reviewRepository.save(any())).willReturn(savedReview);
 

--- a/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
@@ -85,11 +85,31 @@ class ReviewServiceTest {
         }
 
         @Test
+        @DisplayName("본인 주문이 아님 → FORBIDDEN 예외")
+        void notOwnerOrder_throwsException() {
+            // given
+            OrderEntity order = mock(OrderEntity.class);
+            given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
+            given(order.getCustomerId()).willReturn("otheruser");
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(order));
+
+            // when / then
+            assertThatThrownBy(() -> reviewService.createReview(ORDER_ID, validRequest(), principal))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.FORBIDDEN));
+
+            verify(reviewRepository, never()).existsByOrderId(any());
+            verify(reviewRepository, never()).save(any());
+        }
+
+        @Test
         @DisplayName("존재하는 orderId, 중복 리뷰 → DUPLICATE_REVIEW 예외")
         void duplicateReview_throwsException() {
             // given
             OrderEntity order = mock(OrderEntity.class);
             given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
+            given(order.getCustomerId()).willReturn(principal.username());
             given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(order));
             given(reviewRepository.existsByOrderId(ORDER_ID)).willReturn(true);
 
@@ -108,6 +128,7 @@ class ReviewServiceTest {
             // given
             OrderEntity order = mock(OrderEntity.class);
             given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
+            given(order.getCustomerId()).willReturn(principal.username());
 
             ReviewEntity savedReview = ReviewEntity.builder()
                     .orderId(ORDER_ID)

--- a/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
@@ -1,0 +1,111 @@
+package com.example.delivery.review.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
+import com.example.delivery.global.infrastructure.security.UserPrincipal;
+import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.infrastructure.repository.OrderRepository;
+import com.example.delivery.review.domain.entity.ReviewEntity;
+import com.example.delivery.review.domain.repository.ReviewRepository;
+import com.example.delivery.review.presentation.dto.request.ReqCreateReviewDto;
+import com.example.delivery.user.domain.entity.UserRole;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock ReviewRepository reviewRepository;
+    @Mock OrderRepository  orderRepository;
+
+    @InjectMocks ReviewService reviewService;
+
+    // ─── 공통 픽스처 ───────────────────────────────────────────────
+    private static final UUID ORDER_ID = UUID.randomUUID();
+    private static final UUID STORE_ID = UUID.randomUUID();
+
+    private final UserPrincipal principal =
+            new UserPrincipal(1L, "testuser", UserRole.CUSTOMER);
+
+    private ReqCreateReviewDto validRequest() {
+        return new ReqCreateReviewDto(5, "맛있었어요!", STORE_ID);
+    }
+
+    // ─── createReview ──────────────────────────────────────────────
+    @Nested
+    @DisplayName("createReview — 리뷰 생성")
+    class CreateReview {
+
+        @Test
+        @DisplayName("존재하지 않는 orderId → ORDER_NOT_FOUND 예외")
+        void orderNotFound_throwsException() {
+            // given
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.empty());
+
+            // when / then
+            assertThatThrownBy(() -> reviewService.createReview(ORDER_ID, validRequest(), principal))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ORDER_NOT_FOUND));
+
+            verify(reviewRepository, never()).existsByOrderId(any());
+            verify(reviewRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하는 orderId, 중복 리뷰 → DUPLICATE_REVIEW 예외")
+        void duplicateReview_throwsException() {
+            // given
+            given(orderRepository.findById(ORDER_ID))
+                    .willReturn(Optional.of(mock(OrderEntity.class)));
+            given(reviewRepository.existsByOrderId(ORDER_ID)).willReturn(true);
+
+            // when / then
+            assertThatThrownBy(() -> reviewService.createReview(ORDER_ID, validRequest(), principal))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.DUPLICATE_REVIEW));
+
+            verify(reviewRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하는 orderId, 중복 없음 → 리뷰 저장")
+        void success_reviewSaved() {
+            // given
+            ReviewEntity savedReview = ReviewEntity.builder()
+                    .orderId(ORDER_ID)
+                    .storeId(STORE_ID)
+                    .customerId(principal.username())
+                    .rating(5)
+                    .content("맛있었어요!")
+                    .build();
+
+            given(orderRepository.findById(ORDER_ID))
+                    .willReturn(Optional.of(mock(OrderEntity.class)));
+            given(reviewRepository.existsByOrderId(ORDER_ID)).willReturn(false);
+            given(reviewRepository.save(any())).willReturn(savedReview);
+
+            // when
+            reviewService.createReview(ORDER_ID, validRequest(), principal);
+
+            // then
+            verify(reviewRepository).save(any(ReviewEntity.class));
+        }
+    }
+}

--- a/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
@@ -43,7 +43,7 @@ class ReviewServiceTest {
             new UserPrincipal(1L, "testuser", UserRole.CUSTOMER);
 
     private ReqCreateReviewDto validRequest() {
-        return new ReqCreateReviewDto(5, "맛있었어요!", STORE_ID);
+        return new ReqCreateReviewDto(5, "맛있었어요!");
     }
 
     @Nested
@@ -129,6 +129,7 @@ class ReviewServiceTest {
             OrderEntity order = mock(OrderEntity.class);
             given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
             given(order.getCustomerId()).willReturn(principal.username());
+            given(order.getStoreId()).willReturn(STORE_ID);
 
             ReviewEntity savedReview = ReviewEntity.builder()
                     .orderId(ORDER_ID)

--- a/src/test/java/com/example/delivery/review/presentation/controller/ReviewControllerTest.java
+++ b/src/test/java/com/example/delivery/review/presentation/controller/ReviewControllerTest.java
@@ -98,7 +98,7 @@ class ReviewControllerTest {
     @Test
     @DisplayName("리뷰 생성 - 성공")
     void createReview_success() throws Exception {
-        ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!", STORE_ID);
+        ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!");
         given(reviewService.createReview(eq(ORDER_ID), any(), any()))
                 .willReturn(sampleDto());
 
@@ -115,7 +115,7 @@ class ReviewControllerTest {
     @Test
     @DisplayName("리뷰 생성 - 실패: 인증 없음 (401)")
     void createReview_unauthorized() throws Exception {
-        ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!", STORE_ID);
+        ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!");
 
         mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", ORDER_ID)
                         .with(csrf())
@@ -127,7 +127,7 @@ class ReviewControllerTest {
     @Test
     @DisplayName("리뷰 생성 - 실패: 중복 리뷰 (409)")
     void createReview_duplicate() throws Exception {
-        ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!", STORE_ID);
+        ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!");
         given(reviewService.createReview(any(), any(), any()))
                 .willThrow(new BusinessException(ErrorCode.DUPLICATE_REVIEW));
 
@@ -143,22 +143,7 @@ class ReviewControllerTest {
     @DisplayName("리뷰 생성 - 실패: rating 범위 초과 (400)")
     void createReview_invalidRating() throws Exception {
         String reqBody = """
-                {"rating": 6, "storeId": "%s"}
-                """.formatted(STORE_ID);
-
-        mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", ORDER_ID)
-                        .with(authentication(auth(principal)))
-                        .with(csrf())
-                        .contentType(APPLICATION_JSON)
-                        .content(reqBody))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("리뷰 생성 - 실패: storeId 누락 (400)")
-    void createReview_missingStoreId() throws Exception {
-        String reqBody = """
-                {"rating": 5}
+                {"rating": 6}
                 """;
 
         mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", ORDER_ID)


### PR DESCRIPTION
## 개요

리뷰 도메인에서 타 도메인(Order, Store, User)에 대한 의존성을 주입하고, 리뷰 생성/수정/삭제에 필요한 비즈니스 로직 완성

  ---
## 구현 내용

### 1. 리뷰 생성 검증
  - 주문 존재 여부 검증 (ORDER_NOT_FOUND)
  - 주문 완료 상태(COMPLETED) 검증 (ORDER_NOT_COMPLETED)
  - 본인 주문 여부 검증 (FORBIDDEN)
  - 1주문 1리뷰 중복 검증 (DUPLICATE_REVIEW)
  - OrderEntity에서 storeId 추출

### 2. 리뷰 응답 필드 실제 조회
  - storeName: StoreRepository로 실제 가게명 조회
  - customerNickname: UserRepository로 실제 닉네임 조회
  - 기존 플레이스홀더("임시 가게명", "임시 닉네임") 제거

### 3. 가게 평균 평점 자동 재계산
  - 리뷰 생성/수정/삭제 시 StoreEntity.recalculateAverageRating() 호출
  - recalculateStoreRating() 반환 타입 void → StoreEntity로 변경해 중복 DB 조회 제거

### 4. 권한 제어
  - 리뷰 작성: CUSTOMER만 허용
  - 리뷰 수정: CUSTOMER 본인만 허용
  - 리뷰 삭제: CUSTOMER 본인 또는 MANAGER / MASTER 허용
  - 목록 조회: 페이지 사이즈 10/30/50 제한

### 5. 코드 정리
  - 미사용 calculateAverageRating() dead code 제거 (ReviewRepository, ReviewJpaRepository)

  ---
## 테스트 내용

### 1. ReviewServiceTest (단위 테스트, Mockito)
  - createReview: 예외 케이스 4개 + 성공 시 평점 반영 1개
  - updateReview: 예외 케이스 2개 + 평점 계산 케이스 4개 (단일/복수/반올림)
  - deleteReview: 예외 케이스 2개 + CUSTOMER/MASTER 삭제 성공 2개

### 2. ReviewControllerTest (슬라이스 테스트, WebMvcTest)
  - 인증/인가 검증: 401(미인증), 403(권한 없음) 케이스 전 엔드포인트 커버
  - 리뷰 작성 OWNER/MANAGER/MASTER 차단 확인
  - 리뷰 수정 OWNER/MANAGER/MASTER 차단 확인
  - 리뷰 삭제 MANAGER/MASTER 허용, OWNER 차단 확인
