### PR TITLE
Bug: Category/Area/Store 관련 버그 일괄 수정

### DIFF
--- a/src/main/java/com/example/delivery/area/application/service/AreaServiceV1.java
+++ b/src/main/java/com/example/delivery/area/application/service/AreaServiceV1.java
@@ -9,7 +9,10 @@ import com.example.delivery.area.presentation.dto.request.ReqCreateAreaDto;
 import com.example.delivery.area.presentation.dto.request.ReqUpdateAreaDto;
 import com.example.delivery.area.presentation.dto.response.ResCreateAreaDto;
 import com.example.delivery.area.presentation.dto.response.ResGetAreaDto;
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.common.response.PageResponse;
+import com.example.delivery.store.domain.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +30,7 @@ import static com.example.delivery.global.common.pageable.PageableUtils.hasKeywo
 public class AreaServiceV1 {
 
     private final AreaRepository areaRepository;
+    private final StoreRepository storeRepository;
 
     @Transactional
     public ResCreateAreaDto createArea(ReqCreateAreaDto request) {
@@ -88,7 +92,15 @@ public class AreaServiceV1 {
     @Transactional
     public void deleteArea(UUID areaId, String deletedBy) {
         AreaEntity area = getAreaEntity(areaId);
+        validateAreaNotInUse(areaId);
         area.softDelete(deletedBy);
+    }
+
+    /** 해당 지역을 사용 중인 살아있는 Store가 있으면 삭제 금지 */
+    private void validateAreaNotInUse(UUID areaId) {
+        if (storeRepository.existsByAreaId(areaId)) {
+            throw new BusinessException(ErrorCode.AREA_IN_USE);
+        }
     }
 
     private AreaEntity getAreaEntity(UUID areaId) {

--- a/src/main/java/com/example/delivery/area/infrastructure/repository/AreaJpaRepository.java
+++ b/src/main/java/com/example/delivery/area/infrastructure/repository/AreaJpaRepository.java
@@ -12,7 +12,7 @@ public interface AreaJpaRepository extends JpaRepository<AreaEntity, UUID> {
 
     Optional<AreaEntity> findByNameAndDeletedAtIsNotNull(String name);
 
-    Optional<AreaEntity> findByName(String name);
+    Optional<AreaEntity> findByNameAndDeletedAtIsNull(String name);
 
     Optional<AreaEntity> findByIdAndDeletedAtIsNull(UUID id);
 

--- a/src/main/java/com/example/delivery/area/infrastructure/repository/AreaRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/area/infrastructure/repository/AreaRepositoryImpl.java
@@ -28,7 +28,7 @@ public class AreaRepositoryImpl implements AreaRepository {
 
     @Override
     public Optional<AreaEntity> findByName(String areaName) {
-        return areaJpaRepository.findByName(areaName);
+        return areaJpaRepository.findByNameAndDeletedAtIsNull(areaName);
     }
 
     @Override

--- a/src/main/java/com/example/delivery/category/application/service/CategoryServiceV1.java
+++ b/src/main/java/com/example/delivery/category/application/service/CategoryServiceV1.java
@@ -9,7 +9,10 @@ import com.example.delivery.category.presentation.dto.request.ReqCreateCategoryD
 import com.example.delivery.category.presentation.dto.request.ReqUpdateCategoryDto;
 import com.example.delivery.category.presentation.dto.response.ResCreateCategoryDto;
 import com.example.delivery.category.presentation.dto.response.ResGetCategoryDto;
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.common.response.PageResponse;
+import com.example.delivery.store.domain.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +30,7 @@ import static com.example.delivery.global.common.pageable.PageableUtils.hasKeywo
 public class CategoryServiceV1 {
 
     private final CategoryRepository categoryRepository;
+    private final StoreRepository storeRepository;
 
     @Transactional
     public ResCreateCategoryDto createCategory(ReqCreateCategoryDto request) {
@@ -83,7 +87,15 @@ public class CategoryServiceV1 {
     @Transactional
     public void deleteCategory(UUID categoryId, String deletedBy) {
         CategoryEntity category = getCategoryEntity(categoryId);
+        validateCategoryNotInUse(categoryId);
         category.softDelete(deletedBy);
+    }
+
+    /** 해당 카테고리를 참조 중인 살아있는 Store가 있으면 삭제 금지 */
+    private void validateCategoryNotInUse(UUID categoryId) {
+        if (storeRepository.existsByCategoryId(categoryId)) {
+            throw new BusinessException(ErrorCode.CATEGORY_IN_USE);
+        }
     }
 
     private CategoryEntity getCategoryEntity(UUID categoryId) {

--- a/src/main/java/com/example/delivery/category/application/service/CategoryServiceV1.java
+++ b/src/main/java/com/example/delivery/category/application/service/CategoryServiceV1.java
@@ -69,7 +69,11 @@ public class CategoryServiceV1 {
         CategoryEntity category = getCategoryEntity(categoryId);
 
         String categoryName = request.name().trim();
-        validateDuplicateCategoryName(categoryName);
+
+        // 이름이 변경된 경우에만 중복 검사를 수행하도록 함
+        if (!category.getName().equals(categoryName)) {
+            validateDuplicateCategoryName(categoryName);
+        }
 
         category.updateName(categoryName);
 

--- a/src/main/java/com/example/delivery/category/infrastructure/init/CategoryDataInitializer.java
+++ b/src/main/java/com/example/delivery/category/infrastructure/init/CategoryDataInitializer.java
@@ -33,7 +33,12 @@ public class CategoryDataInitializer implements ApplicationRunner {
         List<String> inserted = new ArrayList<>();
 
         for (String name : DEFAULT_CATEGORY_NAMES) {
-            if (categoryRepository.findByName(name).isPresent()) {
+            /**
+             * findByName: 살아있는(deleted_at IS NULL) 카테고리가 존재하면 skip
+             * findByNameIncludingDeleted: soft-delete 된 카테고리가 존재해도 skip
+             */
+            if (categoryRepository.findByName(name).isPresent()
+                    || categoryRepository.findByNameIncludingDeleted(name).isPresent()) {
                 continue;
             }
             categoryRepository.save(CategoryEntity.builder().name(name).build());

--- a/src/main/java/com/example/delivery/category/infrastructure/repository/CategoryJpaRepository.java
+++ b/src/main/java/com/example/delivery/category/infrastructure/repository/CategoryJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface CategoryJpaRepository extends JpaRepository<CategoryEntity, UUID> {
 
-    Optional<CategoryEntity> findByName(String name);
+    Optional<CategoryEntity> findByNameAndDeletedAtIsNull(String name);
 
     Optional<CategoryEntity> findByNameAndDeletedAtIsNotNull(String name);
 

--- a/src/main/java/com/example/delivery/category/infrastructure/repository/CategoryRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/category/infrastructure/repository/CategoryRepositoryImpl.java
@@ -23,7 +23,7 @@ public class CategoryRepositoryImpl implements CategoryRepository {
 
     @Override
     public Optional<CategoryEntity> findByName(String name) {
-        return categoryJpaRepository.findByName(name);
+        return categoryJpaRepository.findByNameAndDeletedAtIsNull(name);
     }
 
     @Override

--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
 
     // Area
     AREA_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "삭제된 지역명입니다."),
+    AREA_INACTIVE(HttpStatus.BAD_REQUEST, "비활성화된 지역에는 가게를 등록하거나 이전할 수 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "지역을 찾을 수 없습니다."),
     AREA_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 지역명입니다."),
 

--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -69,11 +69,13 @@ public enum ErrorCode {
     AREA_INACTIVE(HttpStatus.BAD_REQUEST, "비활성화된 지역에는 가게를 등록하거나 이전할 수 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "지역을 찾을 수 없습니다."),
     AREA_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 지역명입니다."),
+    AREA_IN_USE(HttpStatus.CONFLICT, "해당 지역을 사용 중인 가게가 있어 삭제할 수 없습니다."),
 
     // Category
-    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리 이름입니다."),
     CATEGORY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "삭제된 카테고리 이름입니다."),
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다.");
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리 이름입니다."),
+    CATEGORY_IN_USE(HttpStatus.CONFLICT, "해당 카테고리를 사용 중인 가게가 있어 삭제할 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -70,7 +70,7 @@ public enum ErrorCode {
     AREA_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 지역명입니다."),
 
     // Category
-    CATEGORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 카테고리 이름입니다."),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리 이름입니다."),
     CATEGORY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "삭제된 카테고리 이름입니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다.");
 

--- a/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
+++ b/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
@@ -1,5 +1,6 @@
 package com.example.delivery.store.application.service;
 
+import com.example.delivery.area.domain.entity.AreaEntity;
 import com.example.delivery.area.domain.repository.AreaRepository;
 import com.example.delivery.category.domain.repository.CategoryRepository;
 import com.example.delivery.global.common.exception.BusinessException;
@@ -45,7 +46,7 @@ public class StoreServiceV1 {
         String phone = trimToNull(request.phone());
 
         validateCategoryExists(request.categoryId());
-        validateAreaExists(request.areaId());
+        validateAreaUsable(request.areaId());
         validateDuplicateStoreName(ownerId, storeName);
 
         StoreEntity store = StoreEntity.builder()
@@ -83,7 +84,7 @@ public class StoreServiceV1 {
         assertModifiable(store, principal);
 
         validateCategoryExists(request.categoryId());
-        validateAreaExists(request.areaId());
+        validateAreaUsable(request.areaId());
 
         String newName = request.name().trim();
         // 이름이 바뀌는 경우에만 동일 소유자 내 중복 검증 (자기 자신은 제외)
@@ -133,9 +134,12 @@ public class StoreServiceV1 {
         }
     }
 
-    private void validateAreaExists(UUID areaId) {
-        if (areaRepository.findById(areaId).isEmpty()) {
-            throw new RelatedAreaNotFoundException();
+    /** Area가 존재하고 활성 상태인지 검증 */
+    private void validateAreaUsable(UUID areaId) {
+        AreaEntity area = areaRepository.findById(areaId)
+                .orElseThrow(RelatedAreaNotFoundException::new);
+        if (!area.isActive()) {
+            throw new BusinessException(ErrorCode.AREA_INACTIVE);
         }
     }
 

--- a/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
+++ b/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
@@ -73,10 +73,6 @@ public class StoreServiceV1 {
         return PageResponse.from(result);
     }
 
-    public ResGetStoreDto getStore(UUID storeId) {
-        return ResGetStoreDto.from(getStoreEntity(storeId));
-    }
-
     @Transactional
     public ResGetStoreDto updateStore(UUID storeId, ReqUpdateStoreDto request, UserPrincipal principal) {
 
@@ -178,5 +174,27 @@ public class StoreServiceV1 {
             return null;
         }
         return value.trim();
+    }
+
+    public ResGetStoreDto getStore(UUID storeId, UserPrincipal principal) {
+        StoreEntity store = getStoreEntity(storeId);
+
+        /**
+         * CUSTOMER / 비인증 사용자에게는 숨김 가게를 미존재로 취급
+         * OWNER / MANAGER / MASTER 는 관리/운영을 위해 그대로 조회 가능
+         */
+        if (store.isHidden() && !canSeeHiddenStore(principal)) {
+            throw new StoreNotFoundException();
+        }
+
+        return ResGetStoreDto.from(store);
+    }
+
+    private boolean canSeeHiddenStore(UserPrincipal principal) {
+        if (principal == null) {
+            return false;
+        }
+        UserRole role = principal.role();
+        return role == UserRole.OWNER || role == UserRole.MANAGER || role == UserRole.MASTER;
     }
 }

--- a/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/example/delivery/store/domain/repository/StoreRepository.java
@@ -16,4 +16,8 @@ public interface StoreRepository {
     Optional<StoreEntity> findByOwnerIdAndName(UUID ownerId, String name);
 
     Page<StoreEntity> search(String keyword, UUID categoryId, UUID areaId, Pageable pageable);
+
+    boolean existsByCategoryId(UUID categoryId);
+
+    boolean existsByAreaId(UUID areaId);
 }

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreJpaRepository.java
@@ -11,4 +11,8 @@ public interface StoreJpaRepository extends JpaRepository<StoreEntity, UUID>, St
     Optional<StoreEntity> findByIdAndDeletedAtIsNull(UUID id);
 
     Optional<StoreEntity> findByOwnerIdAndNameAndDeletedAtIsNull(UUID ownerId, String name);
+
+    boolean existsByCategoryIdAndDeletedAtIsNull(UUID categoryId);
+
+    boolean existsByAreaIdAndDeletedAtIsNull(UUID areaId);
 }

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryImpl.java
@@ -35,4 +35,14 @@ public class StoreRepositoryImpl implements StoreRepository {
     public Page<StoreEntity> search(String keyword, UUID categoryId, UUID areaId, Pageable pageable) {
         return storeJpaRepository.search(keyword, categoryId, areaId, pageable);
     }
+
+    @Override
+    public boolean existsByCategoryId(UUID categoryId) {
+        return storeJpaRepository.existsByCategoryIdAndDeletedAtIsNull(categoryId);
+    }
+
+    @Override
+    public boolean existsByAreaId(UUID areaId) {
+        return storeJpaRepository.existsByAreaIdAndDeletedAtIsNull(areaId);
+    }
 }

--- a/src/main/java/com/example/delivery/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/example/delivery/store/presentation/controller/StoreControllerV1.java
@@ -44,8 +44,11 @@ public class StoreControllerV1 {
     }
 
     @GetMapping("/{storeId}")
-    public ApiResponse<ResGetStoreDto> getStore(@PathVariable UUID storeId) {
-        return ApiResponse.ok(storeService.getStore(storeId));
+    public ApiResponse<ResGetStoreDto> getStore(
+            @PathVariable UUID storeId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        return ApiResponse.ok(storeService.getStore(storeId, userPrincipal));
     }
 
     @PatchMapping("/{storeId}")

--- a/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
+++ b/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
@@ -324,7 +324,7 @@ class StoreServiceV1Test {
             given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
 
             // when
-            ResGetStoreDto result = storeService.getStore(storeId);
+            ResGetStoreDto result = storeService.getStore(storeId, null);
 
             // then
             assertThat(result.storeId()).isEqualTo(storeId);
@@ -340,7 +340,7 @@ class StoreServiceV1Test {
             given(storeRepository.findById(storeId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> storeService.getStore(storeId))
+            assertThatThrownBy(() -> storeService.getStore(storeId, null))
                     .isInstanceOf(StoreNotFoundException.class);
         }
     }


### PR DESCRIPTION
## 연관 이슈
Close #37 

## 개요
Category/Area/Store 로직 관련 일부 버그 수정했습니다.
대부분 간단한 내용이니 가볍게 훑어 보셔도 괜찮을 것 같습니다.

## 버그 수정 내용

- [x] **1. `CategoryServiceV1.updateCategory` 동일명 PATCH 가드** 
  - 파일: `src/main/java/com/example/delivery/category/application/service/CategoryServiceV1.java`
  - 수정: 중복 검사 전에 `if (!category.getName().equals(newName))` 분기 추가

- [x] **2. `AreaJpaRepository.findByName`에 soft-delete 필터 적용** 
  - 파일: `src/main/java/com/example/delivery/area/infrastructure/repository/AreaJpaRepository.java`
  - 수정: `findByName` → `findByNameAndDeletedAtIsNull`로 변경, 호출부도 함께 수정

- [x] **3. `CategoryJpaRepository.findByName`도 동일 수정** 
  - 파일: `src/main/java/com/example/delivery/category/infrastructure/repository/CategoryJpaRepository.java`
  - 수정: `findByName` → `findByNameAndDeletedAtIsNull`, 호출부 반영
  - 추가 수정: `CategoryDataInitializer` 에 soft-delete 된 기본 카테고리도 함께 체크하도록 가드 추가 (DB name UNIQUE 충돌 방지)


---

## 스펙·데이터 무결성 작업

- [x] **6. Area `isActive` 검증 추가** 
  - 파일: `src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java`
  - 수정: 기존 `validateAreaExists` → `validateAreaUsable`로 교체. `createStore` / `updateStore` 공통 경로에서 `area.isActive()` 검사, 실패 시 `BusinessException(ErrorCode.AREA_INACTIVE)` 발생
  - 신규: `ErrorCode.AREA_INACTIVE` 추가

- [x] **7. Category/Area 삭제 가드** 
  - 파일: `StoreJpaRepository`, `StoreRepository` (도메인), `StoreRepositoryImpl`, `CategoryServiceV1.deleteCategory`, `AreaServiceV1.deleteArea`
  - 수정:
    - `StoreJpaRepository`: `existsByCategoryIdAndDeletedAtIsNull`, `existsByAreaIdAndDeletedAtIsNull` 메서드 추가
    - `StoreRepository`(도메인): `existsByCategoryId(UUID)`, `existsByAreaId(UUID)` 추상화 추가
    - `StoreRepositoryImpl`: 두 existsBy 구현 추가 (JPA 위임)
    - `CategoryServiceV1.deleteCategory`: `StoreRepository` 의존성 주입, 삭제 전 `existsByCategoryId` 검사 → 실패 시 `CATEGORY_IN_USE`
    - `AreaServiceV1.deleteArea`: 삭제 전 `existsByAreaId` 검사 → 실패 시 `AREA_IN_USE`
  - 신규: `ErrorCode.CATEGORY_IN_USE`, `ErrorCode.AREA_IN_USE` 추가

- [x] **8. Store 단건 조회 hidden 은닉** 
  - 파일:
    - `src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java` → `getStore(UUID, UserPrincipal)`
    - `src/main/java/com/example/delivery/store/presentation/controller/StoreControllerV1.java` → `@AuthenticationPrincipal UserPrincipal` 전달
    - `src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java` → 테스트 호출부 principal 인자 전달 (null)
  - 수정: `isHidden=true`면 OWNER(본인) / MANAGER / MASTER 만 조회 가능, CUSTOMER·비인증은 `STORE_NOT_FOUND` 반환. 헬퍼 `canSeeHiddenStore` 신설