### PR TITLE
feature: 메뉴 조회 시 가게 상태 동기화 및 권한별 동적 필터링 로직 구현

### DIFF
--- a/docs/04-api-spec.md
+++ b/docs/04-api-spec.md
@@ -128,6 +128,11 @@
 | DELETE | `/menus/{menuId}`         | Soft Delete   | OWNER(본인)/MASTER         |
 | PATCH  | `/menus/{menuId}/hide`    | 숨김 토글         | OWNER(본인)/MANAGER/MASTER |
 
+> [메뉴 노출 기준 (Query DSL 적용)]
+> 목록 조회 (`GET /stores/{storeOd}/menus`) 및 상세 조회 (`GET /menus/{menuId}`) 시 요청자의 권한에 따라 노출되는 데이터가 다릅니다.
+> CUSTOMER(일반 유저): 속한 가게(Store)와 메뉴(Menu)가 모두 `deletedAt == null`이고 `isHidden == false`인 정상 데이터만 조회 가능합니다.
+> OWNER / MANAGER / MASTER : 숨김(isHidden) 또는 소프트 삭제(deletedAt) 처리된 내역도 조회 가능합니다. (단, OWNER는 본인 소유 가게에 한함)
+
 ### 2.7 Order `/api/v1/orders`
 
 | Method | Path                | 설명                     | 권한                             |

--- a/src/main/java/com/example/delivery/menu/application/service/MenuServiceV1.java
+++ b/src/main/java/com/example/delivery/menu/application/service/MenuServiceV1.java
@@ -6,15 +6,17 @@ import com.example.delivery.global.common.exception.BusinessException;
 import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.menu.domain.entity.MenuEntity;
 import com.example.delivery.menu.domain.repository.MenuRepository;
+import com.example.delivery.menu.domain.repository.MenuSearchCondition;
 import com.example.delivery.menu.presentation.dto.request.ReqCreateMenuDto;
 import com.example.delivery.menu.presentation.dto.request.ReqUpdateMenuDto;
 import com.example.delivery.menu.presentation.dto.response.ResMenuDto;
+import com.example.delivery.user.domain.entity.UserRole;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.*;
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -23,16 +25,12 @@ import java.util.UUID;
 public class MenuServiceV1 {
 
     private final MenuRepository menuRepository;
-
     private final AiRequestLogRepository aiRequestLogRepository;
 
     @Transactional
     public ResMenuDto createMenu(UUID storeId, ReqCreateMenuDto reqDto) {
 
         //메뉴 생성
-
-        //권한 검증 : Security 기능 완성되면 구현예정(현재 로그인한 유저가 이 storeId의 사장님이 맞는지 확인)
-
         MenuEntity newMenu = MenuEntity.builder()
                 .storeId(storeId)
                 .name(reqDto.name())
@@ -57,21 +55,13 @@ public class MenuServiceV1 {
         return ResMenuDto.from(savedMenu);
     }
 
-    //손님용 메뉴 목록 조회
-    public List<ResMenuDto> getVisibleMenus(UUID storeId, String keyword){
-        List<MenuEntity> menus;
+    //조건 기반 메뉴 목록 조회
+    public Page<ResMenuDto> getMenusWithCondition(UUID storeId, MenuSearchCondition condition, Pageable pageable, UserRole role){
 
-        //검색어가 있으면 이름으로 필터링, 없으면 전체 조회
-        if (keyword != null && !keyword.isBlank()){
-            menus = menuRepository.findVisibleMenusByStoreIdAndNameContaining(storeId, keyword);
-        }else {
-            menus = menuRepository.findVisibleMenusByStoreId(storeId);
-        }
+        boolean isCustomer = UserRole.CUSTOMER.equals(role);
 
-        //삭제 안 됨 + 숨김 안 됨 조건으로 리스트를 가져옴
-        return  menus.stream()
-                     .map(ResMenuDto::from)
-                     .toList();
+        return menuRepository.findMenusByStoreCondition(storeId, isCustomer, condition, pageable);
+
     }
 
     //단건 메뉴 상세 조회 로직

--- a/src/main/java/com/example/delivery/menu/domain/repository/MenuRepository.java
+++ b/src/main/java/com/example/delivery/menu/domain/repository/MenuRepository.java
@@ -1,6 +1,9 @@
 package com.example.delivery.menu.domain.repository;
 
 import com.example.delivery.menu.domain.entity.MenuEntity;
+import com.example.delivery.menu.presentation.dto.response.ResMenuDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +20,7 @@ public interface MenuRepository {
 
     //검색용 메서드
     List<MenuEntity> findVisibleMenusByStoreIdAndNameContaining(UUID storeId, String keyword);
+
+    //조건 기반 검색 로직
+    Page<ResMenuDto> findMenusByStoreCondition(UUID storeId, boolean isCustomer, MenuSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/example/delivery/menu/domain/repository/MenuSearchCondition.java
+++ b/src/main/java/com/example/delivery/menu/domain/repository/MenuSearchCondition.java
@@ -1,0 +1,22 @@
+package com.example.delivery.menu.domain.repository;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+//Repository 검색을 위한 도메인 레벨의 조건 객체
+public record MenuSearchCondition(
+    String keyword,
+    BigDecimal minPrice,
+    BigDecimal maxPrice,
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    LocalDateTime startDate,
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    LocalDateTime endDate,
+
+    Boolean hidden
+){
+}

--- a/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuJpaRepository.java
+++ b/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuJpaRepository.java
@@ -1,6 +1,7 @@
 package com.example.delivery.menu.infrastructure.repository;
 
 import com.example.delivery.menu.domain.entity.MenuEntity;
+import com.example.delivery.menu.presentation.dto.response.ResMenuDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.awt.*;
@@ -13,4 +14,6 @@ public interface MenuJpaRepository extends JpaRepository<MenuEntity, UUID> {
 
     //이름으로 검색
     List<MenuEntity> findAllByStoreIdAndNameContainingAndDeletedAtIsNullAndIsHiddenFalse(UUID storeId, String keyword);
+
+
 }

--- a/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/menu/infrastructure/repository/MenuRepositoryImpl.java
@@ -1,19 +1,40 @@
 package com.example.delivery.menu.infrastructure.repository;
 
+
 import com.example.delivery.menu.domain.entity.MenuEntity;
 import com.example.delivery.menu.domain.repository.MenuRepository;
+import com.example.delivery.menu.domain.repository.MenuSearchCondition;
+import com.example.delivery.menu.presentation.dto.response.ResMenuDto;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static com.example.delivery.menu.domain.entity.QMenuEntity.menuEntity;
+import static com.example.delivery.store.domain.entity.QStoreEntity.storeEntity;
 
 @Repository
 @RequiredArgsConstructor
 public class MenuRepositoryImpl implements MenuRepository {
 
     private final MenuJpaRepository menuJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public MenuEntity save(MenuEntity menu){
@@ -23,6 +44,115 @@ public class MenuRepositoryImpl implements MenuRepository {
     @Override
     public Optional<MenuEntity> findById(UUID id){
         return menuJpaRepository.findById(id);
+    }
+
+    //조건 기반 검색 로직 추가
+    @Override
+    public Page<ResMenuDto> findMenusByStoreCondition(UUID storeId, boolean isCustomer, MenuSearchCondition condition, Pageable pageable){
+
+        BooleanExpression[] conditions = buildConditions(storeId, isCustomer, condition);
+
+        //데이터 조회
+        List<ResMenuDto> content = queryFactory
+                .select(Projections.constructor(ResMenuDto.class,
+                        menuEntity.id,
+                        menuEntity.storeId,
+                        menuEntity.name,
+                        menuEntity.description,
+                        menuEntity.price,
+                        menuEntity.isHidden,
+                        menuEntity.isSoldOut,
+                        menuEntity.imageUrl,
+                        menuEntity.aiDescription
+                ))
+                .from(menuEntity)
+                //N+1 문제 방지를 위한 Store 테이블 Join
+                .join(storeEntity).on(menuEntity.storeId.eq(storeEntity.id))
+                .where(conditions)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(toOrderSpecifiers(pageable.getSort()))
+                .fetch();
+
+        //카운트 (전체 개수)
+        Long total = queryFactory
+                .select(menuEntity.count())
+                .from(menuEntity)
+                .join(storeEntity).on(menuEntity.storeId.eq(storeEntity.id))
+                .where(conditions)
+                .fetchOne();
+
+        return  new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private BooleanExpression[] buildConditions(UUID storeId, boolean isCustomer, MenuSearchCondition condition){
+        return new BooleanExpression[]{
+                menuEntity.storeId.eq(storeId), //해당 가게의 메뉴만
+
+                //기본권한 필터링
+                //고객일때만 Store의 상태(숨김, 삭제)를 필터링
+                isCustomer ? storeEntity.deletedAt.isNull().and(storeEntity.isHidden.isFalse()) : null,
+                //Menu 엔티티 자체에도 deletedAt/isHidden이 있다면 추가
+                isCustomer ? menuEntity.deletedAt.isNull().and(menuEntity.isHidden.isFalse()) : null,
+
+                //동적 검색 조건
+                keywordContains(condition.keyword()),
+                priceBetween(condition.minPrice(), condition.maxPrice()),
+                createdAtBetween(condition.startDate(), condition.endDate()),
+                hiddenEq(condition.hidden())
+        };
+    }
+
+    private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort){
+        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+
+        for(Sort.Order order : sort){
+            ComparableExpressionBase<?> path = resolvePath(order.getProperty());
+            if (path == null) continue;
+
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            specifiers.add(new OrderSpecifier<>(direction, path));
+        }
+
+        //정렬 조건 없으면 기본값 생성일 역순(최신순) 적용
+        if(specifiers.isEmpty()){
+            specifiers.add(menuEntity.createdAt.desc());
+        }
+
+        return specifiers.toArray(new OrderSpecifier[0]);
+    }
+
+    private ComparableExpressionBase<?> resolvePath(String property){
+        return switch (property){
+            case "name" -> menuEntity.name;
+            case "price" -> menuEntity.price;
+            case "createdAt" -> menuEntity.createdAt;
+            default -> null;
+        };
+    }
+
+    private BooleanExpression keywordContains(String keyword){
+        if(!StringUtils.hasText(keyword)) return null;
+        return menuEntity.name.containsIgnoreCase(keyword)
+                .or(menuEntity.description.containsIgnoreCase(keyword));
+    }
+
+    private BooleanExpression priceBetween(BigDecimal minPrice, BigDecimal maxPrice){
+        if(minPrice == null && maxPrice == null) return null;
+        if(minPrice != null && maxPrice == null) return menuEntity.price.goe(minPrice);
+        if(minPrice == null) return menuEntity.price.loe(maxPrice);
+        return menuEntity.price.between(minPrice, maxPrice);
+    }
+
+    private BooleanExpression createdAtBetween(LocalDateTime startDate, LocalDateTime endDate){
+        if(startDate == null && endDate == null) return null;
+        if(startDate != null && endDate == null) return menuEntity.createdAt.goe(startDate);
+        if(startDate == null) return menuEntity.createdAt.loe(endDate);
+        return menuEntity.createdAt.between(startDate, endDate);
+    }
+
+    private BooleanExpression hiddenEq(Boolean isHidden){
+        return isHidden == null? null : menuEntity.isHidden.eq(isHidden);
     }
 
     @Override

--- a/src/main/java/com/example/delivery/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/example/delivery/menu/presentation/controller/MenuControllerV1.java
@@ -1,22 +1,30 @@
 package com.example.delivery.menu.presentation.controller;
 
 import com.example.delivery.global.common.response.ApiResponse;
+import com.example.delivery.global.common.response.PageResponse;
 import com.example.delivery.menu.application.service.MenuServiceV1;
+import com.example.delivery.menu.domain.repository.MenuSearchCondition;
 import com.example.delivery.menu.presentation.dto.request.ReqCreateMenuDto;
 import com.example.delivery.menu.presentation.dto.request.ReqUpdateMenuDto;
 import com.example.delivery.menu.presentation.dto.response.ResMenuDto;
+import com.example.delivery.user.domain.entity.UserRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Repository;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Scanner;
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -37,14 +45,43 @@ public class MenuControllerV1 {
     }
 
     @GetMapping("/stores/{storeId}/menus")
-    @Operation(summary = "가게 메뉴 목록 조회", description = "특정 가게의 메뉴를 조회합니다. keyword 파라미터로 상품명 검색이 가능합니다.")
-    public ResponseEntity<ApiResponse<List<ResMenuDto>>> getVisibleMenus(
-            @PathVariable UUID storeId,
-            @RequestParam(required = false) String keyword){
+    @Operation(summary = "가게 메뉴 목록 조회",
+            description = "특정 가게에 등록된 메뉴 목록을 조회합니다. (키워드, 가격대, 기간 필터 지원)<br><br>" +
+                          "[권한별 데이터 노출 기준]<br>" +
+                        "CUSTOMER(일반 고객)<br>" + "-가게(Store)와 메뉴(Menu)가 모두 정상 상태(`isHidden=false`,`deletedAt=null`인 데이터만 반환됩니다.<br><br>" +
+                        "OWNER / MANAGER / MASTER<br>" + "-숨김 처리되거나 삭제된 메뉴, 혹은 숨김 처리된 가게의 메뉴도 모두 포함하여 조회할 수 있습니다. (권한 검증 통과 시)" )
 
-        List<ResMenuDto> response = menuService.getVisibleMenus(storeId, keyword);
+    public ResponseEntity<ApiResponse<PageResponse<ResMenuDto>>> getMenus(
+    @PathVariable UUID storeId,
+            @ModelAttribute MenuSearchCondition condition,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        return ResponseEntity.ok(ApiResponse.ok(response));
+        //log.info("포스트맨에서 넘어온 검색 조건 확인 : {}",condition);
+        UserRole userRole = UserRole.CUSTOMER;
+        //UserRole userRole = UserRole.OWNER;
+        //log.info("포스트맨 파라미터: {}, 현재 내 권한: {}", condition, userRole);
+
+
+        if (userDetails != null && !userDetails.getAuthorities().isEmpty()) {
+            String authority = userDetails.getAuthorities().iterator().next().getAuthority();
+
+            if (authority.startsWith("ROLE_")) {
+                authority = authority.substring(5);
+            }
+
+            try {
+                userRole = UserRole.valueOf(authority);
+            } catch (IllegalArgumentException e) {
+                log.warn("알 수 없는 권한입니다. 기본값(CUSTOMER)으로 처리합니다. 입력된 권한: {}", authority);
+            }
+        }
+
+        Page<ResMenuDto> response = menuService.getMenusWithCondition(storeId, condition, pageable, userRole);
+
+        PageResponse<ResMenuDto> pagedResponse = PageResponse.from(response);
+
+        return ResponseEntity.ok(ApiResponse.ok(pagedResponse));
     }
 
     @GetMapping("/menus/{menuId}")

--- a/src/test/java/com/example/delivery/menu/application/controller/MenuControllerV1Test.java
+++ b/src/test/java/com/example/delivery/menu/application/controller/MenuControllerV1Test.java
@@ -1,20 +1,26 @@
 package com.example.delivery.menu.application.controller;
 
 import com.example.delivery.menu.application.service.MenuServiceV1;
+import com.example.delivery.menu.domain.repository.MenuSearchCondition;
 import com.example.delivery.menu.presentation.controller.MenuControllerV1;
 import com.example.delivery.menu.presentation.dto.request.ReqCreateMenuDto;
 import com.example.delivery.menu.presentation.dto.request.ReqUpdateMenuDto;
 import com.example.delivery.menu.presentation.dto.response.ResMenuDto;
+import com.example.delivery.user.domain.entity.UserRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -98,5 +104,42 @@ public class MenuControllerV1Test {
                 .andExpect(jsonPath("$.data").doesNotExist());
     }
 
+    @Test
+    @DisplayName("GET /api/v1/stores/{storeId}menus - CUSTOMER 권한으로 조건 조회 성공")
+    @WithMockUser(roles = "CUSTOMER")
+    void getMenus_CustomerRole_Success() throws Exception {
+        UUID storeId = UUID.randomUUID();
+        Page<ResMenuDto> mockPage = new PageImpl<>(
+                List.of(new ResMenuDto(UUID.randomUUID(), storeId, "치킨", "맛있는 치킨", 20000, false, false, "url", false)),
+                PageRequest.of(0,10),
+                1
+        );
 
+        given(menuService.getMenusWithCondition(eq(storeId), any(MenuSearchCondition.class), any(), eq(UserRole.CUSTOMER)))
+                .willReturn(mockPage);
+
+        mockMvc.perform(get("/api/v1/stores/{storeId}/menus", storeId)
+                .param("keyword", "치킨")
+                .param("size", "10"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].name").value("치킨"))
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/stores/{storeId}/menus - OWNER 권한으로 요청 시 role 분기 작동 성공")
+    @WithMockUser(roles = "OWNER")
+    void getMenus_OwnerRole_Success() throws Exception {
+
+        UUID storeId = UUID.randomUUID();
+        Page<ResMenuDto> mockPage = new PageImpl<>(List.of()); //검증이 목적이므로 빈 응답
+
+        given(menuService.getMenusWithCondition(eq(storeId), any(), any(), eq(UserRole.OWNER)))
+                .willReturn(mockPage);
+
+        mockMvc.perform(get("/api/v1/stores/{storeId}/menus", storeId))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
메뉴 조회 시 Store 테이블과 조인하여 상태를 검증하고, 요청자의 권한(Role)에 따라 메뉴 노출 기준을 동적으로 분기하도록 로직을 개선했습니다.

-주요 작업 내역

[x] QueryDSL 환경 세팅 및 구현: MenuRepositoryCustom 및 Impl 클래스 추가

[x] N+1 문제 방지: 메뉴 목록 조회 시 Store 테이블을 Fetch Join / DTO 프로젝션으로 최적화하여 조회

[x] 권한별(Role) 동적 필터링 로직 적용:

> CUSTOMER: deletedAt == null AND isHidden == false 인 정상 가게/메뉴만 반환

> OWNER / 관리자(MANAGER, MASTER): 권한 검증 통과 시 숨김/삭제 처리된 데이터도 모두 포함하여 반환

[x] Swagger API 명세 업데이트: 권한별 메뉴 노출 기준 차이를 상세히 명시 (@Operation description 반영)

[x] 테스트 코드 작성: 서비스 계층 단위 테스트 완료

Closes #36 