### PR TITLE
Feature/36 add order search querydsl

### DIFF
--- a/src/main/java/com/example/delivery/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/example/delivery/order/application/service/OrderServiceV1.java
@@ -87,13 +87,13 @@ public class OrderServiceV1 {
 
     /**
      * CUSTOMER 주문 취소.
-     * PENDING 상태 + 생성 후 5분 이내 조건을 OrderEntity가 검증한다.
+     * 본인 여부 + PENDING 상태 + 생성 후 5분 이내 조건을 OrderEntity가 검증한다.
      * Clock을 주입하는 이유는 단위 테스트에서 시간을 고정하기 위함 (현재는 시스템 시계 사용).
      */
     @Transactional
-    public ResOrderDto cancelByCustomer(UUID orderId) {
+    public ResOrderDto cancelByCustomer(UUID orderId, String customerId) {
         OrderEntity order = findOrder(orderId);
-        order.cancelByCustomer(Clock.systemDefaultZone());
+        order.cancelByCustomer(customerId, Clock.systemDefaultZone());
         return ResOrderDto.from(order);
     }
 
@@ -133,12 +133,22 @@ public class OrderServiceV1 {
     }
 
     /**
-     * 요청사항 수정.
-     * PENDING 상태에서만 가능 — 조리가 시작된 이후에는 변경 불가.
-     * (CUSTOMER/MASTER 권한 분기는 Controller 계층에서 처리 예정)
+     * CUSTOMER 요청사항 수정.
+     * 본인 여부 + PENDING 상태 조건을 OrderEntity가 검증한다.
      */
     @Transactional
-    public ResOrderDto updateRequest(UUID orderId, String request) {
+    public ResOrderDto updateRequestByCustomer(UUID orderId, String customerId, String request) {
+        OrderEntity order = findOrder(orderId);
+        order.updateRequestByCustomer(customerId, request);
+        return ResOrderDto.from(order);
+    }
+
+    /**
+     * MASTER 요청사항 수정.
+     * PENDING 상태 조건만 검증, 본인 확인은 생략.
+     */
+    @Transactional
+    public ResOrderDto updateRequestByMaster(UUID orderId, String request) {
         OrderEntity order = findOrder(orderId);
         order.updateRequest(request);
         return ResOrderDto.from(order);

--- a/src/main/java/com/example/delivery/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/example/delivery/order/application/service/OrderServiceV1.java
@@ -80,9 +80,9 @@ public class OrderServiceV1 {
         return ResOrderDto.from(findOrder(orderId));
     }
 
-    /** 목록 조회 — 페이지네이션 지원. */
-    public Page<ResOrderDto> getOrders(Pageable pageable) {
-        return orderRepository.findAll(pageable).map(ResOrderDto::from);
+    /** 목록 조회 — customerId / storeId / status 조건을 선택적으로 적용 (QueryDSL). */
+    public Page<ResOrderDto> getOrders(String customerId, UUID storeId, OrderStatus status, Pageable pageable) {
+        return orderRepository.search(customerId, storeId, status, pageable).map(ResOrderDto::from);
     }
 
     /**

--- a/src/main/java/com/example/delivery/order/domain/entity/OrderEntity.java
+++ b/src/main/java/com/example/delivery/order/domain/entity/OrderEntity.java
@@ -55,6 +55,15 @@ public class OrderEntity extends BaseEntity {
     @Column(name = "request", columnDefinition = "TEXT")
     private String request;
 
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
+    @Column(name = "canceled_at")
+    private LocalDateTime canceledAt;
+
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItemEntity> items = new ArrayList<>();
 
@@ -82,10 +91,12 @@ public class OrderEntity extends BaseEntity {
             throw new BusinessException(ErrorCode.ORDER_CANCEL_TIMEOUT);
         }
         this.status = OrderStatus.CANCELLED;
+        this.canceledAt = now;
     }
 
     public void cancelByMaster(){
         this.status = OrderStatus.CANCELLED;
+        this.canceledAt = LocalDateTime.now();
     }
 
     public void changeStatusByOwner(OrderStatus next){
@@ -94,6 +105,7 @@ public class OrderEntity extends BaseEntity {
                     "OWNER는 %s -> %s로 전이할 수 없습니다.".formatted(this.status, next));
         }
         this.status = next;
+        stampTransition(next);
     }
 
     public void changeStatusByManager(OrderStatus next){
@@ -102,10 +114,22 @@ public class OrderEntity extends BaseEntity {
                     "MANAGER는 주문을 취소할 수 없습니다. (현재: %s)".formatted(this.status));
         }
         this.status = next;
+        stampTransition(next);
     }
 
     public void changeStatusByMaster(OrderStatus next){
         this.status = next;
+        stampTransition(next);
+    }
+
+    private void stampTransition(OrderStatus next){
+        LocalDateTime now = LocalDateTime.now();
+        switch (next){
+            case ACCEPTED -> this.acceptedAt = now;
+            case DELIVERED -> this.deliveredAt = now;
+            case CANCELLED -> this.canceledAt = now;
+            default -> {}
+        }
     }
 
     public void updateRequest(String request){

--- a/src/main/java/com/example/delivery/order/domain/entity/OrderEntity.java
+++ b/src/main/java/com/example/delivery/order/domain/entity/OrderEntity.java
@@ -81,7 +81,8 @@ public class OrderEntity extends BaseEntity {
         item.assignOrder(this);
     }
 
-    public void cancelByCustomer(Clock clock){
+    public void cancelByCustomer(String requesterId, Clock clock){
+        verifyCustomer(requesterId);
         if(this.status != OrderStatus.PENDING){
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS,
                     "PENDING 상태에서만 취소 가능합니다. (현재: %s)".formatted(this.status));
@@ -132,11 +133,23 @@ public class OrderEntity extends BaseEntity {
         }
     }
 
+    public void updateRequestByCustomer(String requesterId, String request){
+        verifyCustomer(requesterId);
+        updateRequest(request);
+    }
+
     public void updateRequest(String request){
         if(this.status != OrderStatus.PENDING){
             throw new BusinessException(ErrorCode.INVALID_ORDER_STATUS,
                     "PENDING 상태에서만 요청사항을 수정할 수 있습니다. (현재: %s)".formatted(this.status));
         }
         this.request = request;
+    }
+
+    private void verifyCustomer(String requesterId){
+        if(!this.customerId.equals(requesterId)){
+            throw new BusinessException(ErrorCode.FORBIDDEN,
+                    "본인 주문만 처리할 수 있습니다.");
+        }
     }
 }

--- a/src/main/java/com/example/delivery/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/example/delivery/order/domain/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.example.delivery.order.domain.repository;
 
 import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.domain.entity.OrderStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,5 +14,5 @@ public interface OrderRepository {
 
     Optional<OrderEntity> findById(UUID orderId);
 
-    Page<OrderEntity> findAll(Pageable pageable);
+    Page<OrderEntity> search(String customerId, UUID storeId, OrderStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/delivery/order/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/example/delivery/order/infrastructure/repository/OrderJpaRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface OrderJpaRepository extends JpaRepository<OrderEntity, UUID> {
+public interface OrderJpaRepository extends JpaRepository<OrderEntity, UUID>, OrderRepositoryCustom {
 }

--- a/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.example.delivery.order.infrastructure.repository;
+
+import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.domain.entity.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+/**
+ * Order 복합 검색 전용 Custom 레포지토리.
+ * customerId / storeId / status 조건을 선택적으로 조합해 QueryDSL 로 조회한다.
+ */
+public interface OrderRepositoryCustom {
+
+    Page<OrderEntity> search(String customerId, UUID storeId, OrderStatus status, Pageable pageable);
+}

--- a/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryCustomImpl.java
@@ -58,7 +58,7 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
     }
 
     /**
-     * 조건 조립 (null 이면 조건 자체를 제외)
+     * 조건 조립 (null이면 조건 자체를 제외)
      */
     private BooleanExpression notDeleted() {
         return ORDER.deletedAt.isNull();

--- a/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryCustomImpl.java
@@ -1,0 +1,111 @@
+package com.example.delivery.order.infrastructure.repository;
+
+import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.domain.entity.OrderStatus;
+import com.example.delivery.order.domain.entity.QOrderEntity;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
+
+    private static final QOrderEntity ORDER = QOrderEntity.orderEntity;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<OrderEntity> search(String customerId, UUID storeId, OrderStatus status, Pageable pageable) {
+
+        BooleanExpression[] conditions = new BooleanExpression[]{
+                notDeleted(),
+                customerIdEq(customerId),
+                storeIdEq(storeId),
+                statusEq(status)
+        };
+
+        List<OrderEntity> content = queryFactory
+                .selectFrom(ORDER)
+                .where(conditions)
+                .orderBy(toOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(ORDER.count())
+                .from(ORDER)
+                .where(conditions)
+                .fetchOne();
+
+        long total = totalCount != null ? totalCount : 0L;
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * 조건 조립 (null 이면 조건 자체를 제외)
+     */
+    private BooleanExpression notDeleted() {
+        return ORDER.deletedAt.isNull();
+    }
+
+    private BooleanExpression customerIdEq(String customerId) {
+        return StringUtils.hasText(customerId) ? ORDER.customerId.eq(customerId) : null;
+    }
+
+    private BooleanExpression storeIdEq(UUID storeId) {
+        return storeId == null ? null : ORDER.storeId.eq(storeId);
+    }
+
+    private BooleanExpression statusEq(OrderStatus status) {
+        return status == null ? null : ORDER.status.eq(status);
+    }
+
+    /**
+     * 정렬
+     * Pageable 의 Sort 를 QueryDSL OrderSpecifier 로 변환
+     * 지원 속성: createdAt, updatedAt
+     * 지원하지 않는 속성은 무시하고, 결과가 비면 createdAt DESC 를 기본 적용
+     */
+    private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+
+        for (Sort.Order order : sort) {
+            ComparableExpressionBase<?> path = resolvePath(order.getProperty());
+            if (path == null) {
+                continue;
+            }
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            specifiers.add(new OrderSpecifier<>(direction, path));
+        }
+
+        if (specifiers.isEmpty()) {
+            specifiers.add(ORDER.createdAt.desc());
+        }
+
+        return specifiers.toArray(new OrderSpecifier[0]);
+    }
+
+    private ComparableExpressionBase<?> resolvePath(String property) {
+        return switch (property) {
+            case "createdAt" -> ORDER.createdAt;
+            case "updatedAt" -> ORDER.updatedAt;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/order/infrastructure/repository/OrderRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.example.delivery.order.infrastructure.repository;
 
 import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.domain.entity.OrderStatus;
 import com.example.delivery.order.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,7 +28,7 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public Page<OrderEntity> findAll(Pageable pageable) {
-        return orderJpaRepository.findAll(pageable);
+    public Page<OrderEntity> search(String customerId, UUID storeId, OrderStatus status, Pageable pageable) {
+        return orderJpaRepository.search(customerId, storeId, status, pageable);
     }
 }

--- a/src/main/java/com/example/delivery/order/presentation/controller/OrderControllerV1.java
+++ b/src/main/java/com/example/delivery/order/presentation/controller/OrderControllerV1.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -87,12 +88,28 @@ public class OrderControllerV1 {
     }
 
 
-    @Operation(summary = "주문 목록 조회", description = "페이지네이션으로 주문 목록을 조회합니다.")
+    @Operation(summary = "주문 목록 조회",
+            description = "storeId / status 필터 + 페이지네이션. CUSTOMER 는 본인 주문만 조회되며, OWNER/MANAGER/MASTER 는 필터 자유.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음")
+    })
     @GetMapping
     public ApiResponse<Page<ResOrderDto>> getOrders(
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @Parameter(description = "가게 ID 필터") @RequestParam(required = false) UUID storeId,
+            @Parameter(description = "주문 상태 필터") @RequestParam(required = false) OrderStatus status,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
-        return ApiResponse.ok(orderService.getOrders(pageable));
+        if (principal == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        String customerIdFilter = switch (principal.role()) {
+            case CUSTOMER -> principal.username();
+            case OWNER, MANAGER, MASTER -> null;
+        };
+        return ApiResponse.ok(orderService.getOrders(customerIdFilter, storeId, status, pageable));
     }
 
 

--- a/src/main/java/com/example/delivery/order/presentation/controller/OrderControllerV1.java
+++ b/src/main/java/com/example/delivery/order/presentation/controller/OrderControllerV1.java
@@ -41,9 +41,9 @@ import org.springframework.web.bind.annotation.RestController;
  * 올바른 서비스 메서드로 디스패치(허용되지 않은 role은 403 FORBIDDEN.)
  *
  * [본인 확인]
- * CUSTOMER가 본인 주문에만 접근하도록 {@link #verifyOwner}가 {@code getOrder}로 주문을
- * 다시 조회해 {@code customerId}를 비교한다. 서비스 쪽 쓰기 트랜잭션 전에 한 번 더 조회가
- * 발생하므로 향후 서비스/엔티티 쪽으로 이 검증을 내리면 호출 1회로 줄일 수 있다.
+ * CUSTOMER 전용 경로(cancelByCustomer / updateRequestByCustomer)에서는 요청자의 username을
+ * 서비스로 그대로 전달하고, {@link com.example.delivery.order.domain.entity.OrderEntity}가
+ * {@code customerId}와 비교해 FORBIDDEN을 던진다. 컨트롤러는 role 디스패치만 담당.
  *
  * [응답 규약]
  * 모든 응답은 {@link ApiResponse}로 감싸며, 예외는 GlobalExceptionHandler에서 공통 포맷으로
@@ -112,10 +112,7 @@ public class OrderControllerV1 {
     ) {
         return switch (principal.role()) {
             case MASTER -> ApiResponse.ok(orderService.cancelByMaster(orderId));
-            case CUSTOMER -> {
-                verifyOwner(orderId, principal);
-                yield ApiResponse.ok(orderService.cancelByCustomer(orderId));
-            }
+            case CUSTOMER -> ApiResponse.ok(orderService.cancelByCustomer(orderId, principal.username()));
             default -> throw new BusinessException(ErrorCode.FORBIDDEN);
         };
     }
@@ -160,28 +157,17 @@ public class OrderControllerV1 {
             @RequestBody @Valid ReqUpdateRequestDto request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        if (principal.role() == UserRole.CUSTOMER) {
-            verifyOwner(orderId, principal);
-        } else if (principal.role() != UserRole.MASTER) {
-            throw new BusinessException(ErrorCode.FORBIDDEN);
-        }
-        return ApiResponse.ok(orderService.updateRequest(orderId, request.request()));
+        return switch (principal.role()) {
+            case CUSTOMER -> ApiResponse.ok(
+                    orderService.updateRequestByCustomer(orderId, principal.username(), request.request()));
+            case MASTER -> ApiResponse.ok(orderService.updateRequestByMaster(orderId, request.request()));
+            default -> throw new BusinessException(ErrorCode.FORBIDDEN);
+        };
     }
 
     /** 특정 단일 role만 허용. 위반 시 403. */
     private void requireRole(UserPrincipal principal, UserRole expected) {
         if (principal.role() != expected) {
-            throw new BusinessException(ErrorCode.FORBIDDEN);
-        }
-    }
-
-    /**
-     * 주문의 {@code customerId}가 요청자의 {@code username}과 일치하는지 확인한다.
-     * 불일치 시 403. 주문이 없으면 {@code getOrder}에서 ORDER_NOT_FOUND(404)로 먼저 종료된다.
-     */
-    private void verifyOwner(UUID orderId, UserPrincipal principal) {
-        ResOrderDto order = orderService.getOrder(orderId);
-        if (!order.customerId().equals(principal.username())) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
     }

--- a/src/main/java/com/example/delivery/order/presentation/dto/response/ResOrderDto.java
+++ b/src/main/java/com/example/delivery/order/presentation/dto/response/ResOrderDto.java
@@ -5,6 +5,7 @@ import com.example.delivery.order.domain.entity.OrderStatus;
 import com.example.delivery.order.domain.entity.OrderType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -18,6 +19,9 @@ public record ResOrderDto(
         OrderStatus status,
         Integer totalPrice,
         String request,
+        LocalDateTime acceptedAt,
+        LocalDateTime deliveredAt,
+        LocalDateTime canceledAt,
         List<ResOrderItemDto> items
 ) {
     public static ResOrderDto from(OrderEntity entity) {
@@ -30,6 +34,9 @@ public record ResOrderDto(
                 entity.getStatus(),
                 entity.getTotalPrice(),
                 entity.getRequest(),
+                entity.getAcceptedAt(),
+                entity.getDeliveredAt(),
+                entity.getCanceledAt(),
                 entity.getItems().stream().map(ResOrderItemDto::from).toList()
         );
     }

--- a/src/main/java/com/example/delivery/review/application/service/ReviewService.java
+++ b/src/main/java/com/example/delivery/review/application/service/ReviewService.java
@@ -5,7 +5,7 @@ import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.infrastructure.security.UserPrincipal;
 import com.example.delivery.order.domain.entity.OrderEntity;
 import com.example.delivery.order.domain.entity.OrderStatus;
-import com.example.delivery.order.infrastructure.repository.OrderRepository;
+import com.example.delivery.order.domain.repository.OrderRepository;
 import com.example.delivery.review.domain.entity.ReviewEntity;
 import com.example.delivery.review.domain.repository.ReviewRepository;
 import com.example.delivery.review.presentation.dto.request.ReqCreateReviewDto;

--- a/src/test/java/com/example/delivery/order/application/service/OrderServiceV1Test.java
+++ b/src/test/java/com/example/delivery/order/application/service/OrderServiceV1Test.java
@@ -141,10 +141,25 @@ class OrderServiceV1Test {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when
-            ResOrderDto result = orderService.cancelByCustomer(orderId);
+            ResOrderDto result = orderService.cancelByCustomer(orderId, CUSTOMER_ID);
 
             // then
             assertThat(result.status()).isEqualTo(OrderStatus.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("본인 아니면 FORBIDDEN 예외")
+        void notOwner_throwsException() {
+            // given
+            UUID orderId = UUID.randomUUID();
+            OrderEntity order = buildOrder();
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when / then
+            assertThatThrownBy(() -> orderService.cancelByCustomer(orderId, "other"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.FORBIDDEN));
         }
 
         @Test
@@ -157,7 +172,7 @@ class OrderServiceV1Test {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when / then
-            assertThatThrownBy(() -> orderService.cancelByCustomer(orderId))
+            assertThatThrownBy(() -> orderService.cancelByCustomer(orderId, CUSTOMER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_ORDER_STATUS));
@@ -173,7 +188,7 @@ class OrderServiceV1Test {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when / then
-            assertThatThrownBy(() -> orderService.cancelByCustomer(orderId))
+            assertThatThrownBy(() -> orderService.cancelByCustomer(orderId, CUSTOMER_ID))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.ORDER_CANCEL_TIMEOUT));
@@ -311,13 +326,13 @@ class OrderServiceV1Test {
         }
     }
 
-    // ─── updateRequest ───────────────────────────────────────
+    // ─── updateRequestByCustomer ─────────────────────────────
     @Nested
-    @DisplayName("updateRequest — 요청사항 수정")
-    class UpdateRequest {
+    @DisplayName("updateRequestByCustomer — 고객 요청사항 수정")
+    class UpdateRequestByCustomer {
 
         @Test
-        @DisplayName("PENDING 상태에서는 수정 가능")
+        @DisplayName("본인 + PENDING 상태에서는 수정 가능")
         void pending_success() {
             // given
             UUID orderId = UUID.randomUUID();
@@ -325,10 +340,25 @@ class OrderServiceV1Test {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when
-            ResOrderDto result = orderService.updateRequest(orderId, "수정된 요청");
+            ResOrderDto result = orderService.updateRequestByCustomer(orderId, CUSTOMER_ID, "수정된 요청");
 
             // then
             assertThat(result.request()).isEqualTo("수정된 요청");
+        }
+
+        @Test
+        @DisplayName("본인 아니면 FORBIDDEN 예외")
+        void notOwner_throwsException() {
+            // given
+            UUID orderId = UUID.randomUUID();
+            OrderEntity order = buildOrder();
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when / then
+            assertThatThrownBy(() -> orderService.updateRequestByCustomer(orderId, "other", "수정"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.FORBIDDEN));
         }
 
         @Test
@@ -341,7 +371,44 @@ class OrderServiceV1Test {
             given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
             // when / then
-            assertThatThrownBy(() -> orderService.updateRequest(orderId, "수정"))
+            assertThatThrownBy(() -> orderService.updateRequestByCustomer(orderId, CUSTOMER_ID, "수정"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_ORDER_STATUS));
+        }
+    }
+
+    // ─── updateRequestByMaster ───────────────────────────────
+    @Nested
+    @DisplayName("updateRequestByMaster — MASTER 요청사항 수정")
+    class UpdateRequestByMaster {
+
+        @Test
+        @DisplayName("본인 검증 없이 PENDING이면 수정 가능")
+        void pending_success() {
+            // given
+            UUID orderId = UUID.randomUUID();
+            OrderEntity order = buildOrder();
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when
+            ResOrderDto result = orderService.updateRequestByMaster(orderId, "수정");
+
+            // then
+            assertThat(result.request()).isEqualTo("수정");
+        }
+
+        @Test
+        @DisplayName("PENDING이 아니면 INVALID_ORDER_STATUS 예외")
+        void notPending_throwsException() {
+            // given
+            UUID orderId = UUID.randomUUID();
+            OrderEntity order = buildOrder();
+            setStatus(order, OrderStatus.COOKING);
+            given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+            // when / then
+            assertThatThrownBy(() -> orderService.updateRequestByMaster(orderId, "수정"))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_ORDER_STATUS));

--- a/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
+++ b/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
@@ -234,17 +234,38 @@ class OrderControllerV1Test {
     class GetOrders {
 
         @Test
-        @DisplayName("성공 — 페이지 반환")
-        void success() throws Exception {
-            // Page<ResOrderDto>가 JSON 직렬화되어 totalElements가 내려오는지 확인
+        @DisplayName("성공 — MASTER 는 customerId 필터 없이 전체 조회")
+        void master_success() throws Exception {
             Page<ResOrderDto> page = new PageImpl<>(
                     List.of(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING)),
                     PageRequest.of(0, 10), 1);
-            given(orderService.getOrders(any())).willReturn(page);
+            // MASTER → customerIdFilter = null
+            given(orderService.getOrders(eq(null), eq(null), eq(null), any())).willReturn(page);
 
-            mockMvc.perform(get("/api/v1/orders"))
+            mockMvc.perform(get("/api/v1/orders")
+                            .with(authentication(auth(master))))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+
+        @Test
+        @DisplayName("성공 — CUSTOMER 는 customerId 가 본인으로 강제 주입")
+        void customer_filtersByOwnUsername() throws Exception {
+            Page<ResOrderDto> page = new PageImpl<>(
+                    List.of(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING)),
+                    PageRequest.of(0, 10), 1);
+            given(orderService.getOrders(eq(CUSTOMER_NAME), eq(null), eq(null), any())).willReturn(page);
+
+            mockMvc.perform(get("/api/v1/orders")
+                            .with(authentication(auth(customer))))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("실패 — 인증 없으면 403")
+        void unauthenticated_forbidden() throws Exception {
+            mockMvc.perform(get("/api/v1/orders"))
+                    .andExpect(status().isForbidden());
         }
     }
 

--- a/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
+++ b/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
@@ -257,10 +257,8 @@ class OrderControllerV1Test {
         @Test
         @DisplayName("성공 — CUSTOMER 본인")
         void customerOwner_success() throws Exception {
-            // verifyOwner가 getOrder로 customerId를 검증하므로 getOrder도 스텁 필요
-            given(orderService.getOrder(ORDER_ID))
-                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
-            given(orderService.cancelByCustomer(ORDER_ID))
+            // principal.username() 이 서비스 인자로 그대로 전달되고, 엔티티가 본인 확인을 수행
+            given(orderService.cancelByCustomer(ORDER_ID, CUSTOMER_NAME))
                     .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.CANCELLED));
 
             mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
@@ -273,9 +271,9 @@ class OrderControllerV1Test {
         @Test
         @DisplayName("실패 — CUSTOMER 타인 주문 403")
         void customerOther_forbidden() throws Exception {
-            // getOrder가 cust01 소유를 반환 → 요청자는 other → verifyOwner에서 FORBIDDEN
-            given(orderService.getOrder(ORDER_ID))
-                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+            // 요청자는 other → 엔티티의 verifyCustomer 가 FORBIDDEN 을 던짐
+            given(orderService.cancelByCustomer(ORDER_ID, "other"))
+                    .willThrow(new BusinessException(ErrorCode.FORBIDDEN));
 
             mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
                             .with(authentication(auth(otherUser)))
@@ -323,9 +321,7 @@ class OrderControllerV1Test {
         @DisplayName("실패 — CUSTOMER 5분 초과 시 400")
         void customer_timeout() throws Exception {
             // 본인 확인은 통과하지만 엔티티에서 ORDER_CANCEL_TIMEOUT 발생
-            given(orderService.getOrder(ORDER_ID))
-                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
-            given(orderService.cancelByCustomer(ORDER_ID))
+            given(orderService.cancelByCustomer(ORDER_ID, CUSTOMER_NAME))
                     .willThrow(new BusinessException(ErrorCode.ORDER_CANCEL_TIMEOUT));
 
             mockMvc.perform(post("/api/v1/orders/{orderId}/cancel", ORDER_ID)
@@ -432,9 +428,7 @@ class OrderControllerV1Test {
         @Test
         @DisplayName("성공 — CUSTOMER 본인")
         void customerOwner_success() throws Exception {
-            given(orderService.getOrder(ORDER_ID))
-                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
-            given(orderService.updateRequest(ORDER_ID, "수정"))
+            given(orderService.updateRequestByCustomer(ORDER_ID, CUSTOMER_NAME, "수정"))
                     .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
 
             mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
@@ -448,9 +442,9 @@ class OrderControllerV1Test {
         @Test
         @DisplayName("실패 — CUSTOMER 타인 주문 403")
         void customerOther_forbidden() throws Exception {
-            // 본인 확인 실패 → 서비스 updateRequest 호출 없이 FORBIDDEN
-            given(orderService.getOrder(ORDER_ID))
-                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
+            // 엔티티의 verifyCustomer 가 FORBIDDEN 을 던짐
+            given(orderService.updateRequestByCustomer(ORDER_ID, "other", "수정"))
+                    .willThrow(new BusinessException(ErrorCode.FORBIDDEN));
 
             mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
                             .with(authentication(auth(otherUser)))
@@ -463,8 +457,8 @@ class OrderControllerV1Test {
         @Test
         @DisplayName("성공 — MASTER 는 타인 주문도 수정")
         void master_success() throws Exception {
-            // MASTER는 verifyOwner를 건너뛰고 바로 updateRequest 호출
-            given(orderService.updateRequest(ORDER_ID, "수정"))
+            // MASTER는 본인 확인을 생략하는 전용 서비스 메서드로 바로 진입
+            given(orderService.updateRequestByMaster(ORDER_ID, "수정"))
                     .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.PENDING));
 
             mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)
@@ -497,10 +491,8 @@ class OrderControllerV1Test {
         @Test
         @DisplayName("실패 — PENDING 아니면 400")
         void notPending() throws Exception {
-            // 본인 확인은 통과, 엔티티 레벨에서 PENDING 아님 → INVALID_ORDER_STATUS
-            given(orderService.getOrder(ORDER_ID))
-                    .willReturn(sampleOrder(CUSTOMER_NAME, OrderStatus.COOKING));
-            given(orderService.updateRequest(ORDER_ID, "수정"))
+            // 엔티티 레벨에서 PENDING 아님 → INVALID_ORDER_STATUS
+            given(orderService.updateRequestByCustomer(ORDER_ID, CUSTOMER_NAME, "수정"))
                     .willThrow(new BusinessException(ErrorCode.INVALID_ORDER_STATUS));
 
             mockMvc.perform(patch("/api/v1/orders/{orderId}/request", ORDER_ID)

--- a/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
+++ b/src/test/java/com/example/delivery/order/presentation/controller/OrderControllerV1Test.java
@@ -125,6 +125,7 @@ class OrderControllerV1Test {
         return new ResOrderDto(
                 ORDER_ID, customerId, STORE_ID, ADDRESS_ID,
                 OrderType.ONLINE, status, 40_000, "요청",
+                null, null, null,
                 List.of()
         );
     }

--- a/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/delivery/review/application/service/ReviewServiceTest.java
@@ -13,7 +13,7 @@ import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.global.infrastructure.security.UserPrincipal;
 import com.example.delivery.order.domain.entity.OrderEntity;
 import com.example.delivery.order.domain.entity.OrderStatus;
-import com.example.delivery.order.infrastructure.repository.OrderRepository;
+import com.example.delivery.order.domain.repository.OrderRepository;
 import com.example.delivery.review.domain.entity.ReviewEntity;
 import com.example.delivery.review.domain.repository.ReviewRepository;
 import com.example.delivery.review.presentation.dto.request.ReqCreateReviewDto;
@@ -40,7 +40,7 @@ class ReviewServiceTest {
     private static final UUID STORE_ID = UUID.randomUUID();
 
     private final UserPrincipal principal =
-            new UserPrincipal(1L, "testuser", UserRole.CUSTOMER);
+            new UserPrincipal(UUID.randomUUID(), "testuser", UserRole.CUSTOMER);
 
     private ReqCreateReviewDto validRequest() {
         return new ReqCreateReviewDto(5, "맛있었어요!");


### PR DESCRIPTION
## 개요
주문 목록 조회를 QueryDSL 기반 동적 검색으로 전환하고, 그 과정에서 함께 정리한 본인검증/응답 DTO 보강을 포함합니다.

- Base: `main`
- Closes #36, #31

## 주요 변경사항

### 1. QueryDSL 기반 Order 동적 검색 (#36)
- `OrderRepositoryCustom` / `OrderRepositoryCustomImpl` 신규
- 동적 조건: `customerId`, `storeId`, `status` (null이면 조건 자체 제외)
- soft-delete 제외 (`deletedAt IS NULL`) 기본 적용
- 정렬 화이트리스트: `createdAt`, `updatedAt` — 미지원 속성은 무시하고 비면 `createdAt DESC` fallback
- 카운트 쿼리 분리 → `PageImpl`로 페이지 응답

### 2. `GET /api/v1/orders` 컨트롤러 개선
- `storeId`, `status` 쿼리 파라미터 추가
- role별 customerId 자동 주입
  - `CUSTOMER`: 본인 주문으로만 필터
  - `OWNER` / `MANAGER` / `MASTER`: customerId 미적용 (필터 자유)
- 미인증 요청은 403

### 3. 본인검증 리팩토링 (#31)
- 컨트롤러의 `verifyOwner` 제거
- `cancelByCustomer` / `updateRequestByCustomer`가 username을 서비스에 그대로 전달
- `OrderEntity` 도메인 불변식이 `customerId` 비교 후 위반 시 FORBIDDEN
- 컨트롤러는 role 디스패치만 담당 → 쓰기 트랜잭션 전 추가 조회 1회 제거

### 4. `ResOrderDto` 보강
- `acceptedAt`, `deliveredAt`, `canceledAt` 추가 → 클라이언트가 상태 전이 시각을 응답에서 바로 확인

### 5. 빌드 호환성
- main 머지 과정에서 발생한 ReviewServiceTest 컴파일 에러 수정 (Order 메서드 시그니처 변경 반영)

## 변경 파일 (요약)
- `order/infrastructure/repository/OrderRepositoryCustom(.Impl).java` 신규
- `order/presentation/controller/OrderControllerV1.java` — getOrders 시그니처/검증 변경
- `order/domain/entity/OrderEntity.java` — 본인검증 불변식 추가
- `order/presentation/dto/response/ResOrderDto.java` — 시각 필드 추가
- 테스트: `OrderServiceV1Test`, `OrderControllerV1Test`, `ReviewServiceTest` 갱신

## 테스트
- [x] 단위 테스트 (OrderServiceV1Test / OrderControllerV1Test) 통과
- [x] Swagger UI 수동 검증 — CUSTOMER 본인 주문 필터, OWNER 가게 필터, status 필터, 정렬 fallback, soft-delete 제외, 권한 분기

## 참고
- 컨트롤러에서 customerId를 강제 주입하므로, 서비스/리포지토리 테스트만으로는 권한 분기 검증이 부족합니다. 컨트롤러 통합 테스트로 함께 보장합니다.