### PR TITLE
Feature: Store 도메인에 최소주문금액 필드 추가 (#50)

### DIFF
--- a/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
+++ b/src/main/java/com/example/delivery/store/application/service/StoreServiceV1.java
@@ -56,6 +56,7 @@ public class StoreServiceV1 {
                 .name(storeName)
                 .address(address)
                 .phone(phone)
+                .minOrderAmount(request.minOrderAmount())
                 .build();
 
         return ResCreateStoreDto.from(storeRepository.save(store));
@@ -93,7 +94,8 @@ public class StoreServiceV1 {
                 request.areaId(),
                 newName,
                 request.address().trim(),
-                trimToNull(request.phone())
+                trimToNull(request.phone()),
+                request.minOrderAmount()
         );
 
         return ResGetStoreDto.from(store);

--- a/src/main/java/com/example/delivery/store/domain/entity/StoreEntity.java
+++ b/src/main/java/com/example/delivery/store/domain/entity/StoreEntity.java
@@ -55,6 +55,9 @@ public class StoreEntity extends BaseEntity {
     @Column(length = 20)
     private String phone;
 
+    @Column(name = "min_order_amount", nullable = false)
+    private Integer minOrderAmount;
+
     @Column(name = "average_rating", precision = 2, scale = 1, nullable = false)
     private BigDecimal averageRating;
 
@@ -62,13 +65,14 @@ public class StoreEntity extends BaseEntity {
     private boolean isHidden;
 
     @Builder
-    private StoreEntity(UUID ownerId, UUID categoryId, UUID areaId, String name, String address, String phone) {
+    private StoreEntity(UUID ownerId, UUID categoryId, UUID areaId, String name, String address, String phone, Integer minOrderAmount) {
         this.ownerId = ownerId;
         this.categoryId = categoryId;
         this.areaId = areaId;
         this.name = name;
         this.address = address;
         this.phone = phone;
+        this.minOrderAmount = minOrderAmount;
         this.averageRating = DEFAULT_RATING;
         this.isHidden = false;
     }
@@ -76,12 +80,13 @@ public class StoreEntity extends BaseEntity {
     /**
      * 가게 기본 정보 수정. phone 은 null 허용(미입력 시 null 로 덮어씀)
      */
-    public void update(UUID categoryId, UUID areaId, String name, String address, String phone) {
+    public void update(UUID categoryId, UUID areaId, String name, String address, String phone, Integer minOrderAmount) {
         this.categoryId = categoryId;
         this.areaId = areaId;
         this.name = name;
         this.address = address;
         this.phone = phone;
+        this.minOrderAmount = minOrderAmount;
     }
 
     /**

--- a/src/main/java/com/example/delivery/store/presentation/dto/request/ReqCreateStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/request/ReqCreateStoreDto.java
@@ -1,10 +1,7 @@
 package com.example.delivery.store.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 import java.util.UUID;
 
@@ -35,6 +32,10 @@ public record ReqCreateStoreDto(
                 regexp = "^$|^[0-9-]{9,20}$",
                 message = "전화번호 형식이 올바르지 않습니다."
         )
-        String phone
+        String phone,
+
+        @NotNull(message = "최소 주문 금액은 필수입니다.")
+        @PositiveOrZero(message = "최소 주문 금액은 0원 이상이어야 합니다.")
+        Integer minOrderAmount
 ) {
 }

--- a/src/main/java/com/example/delivery/store/presentation/dto/request/ReqUpdateStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/request/ReqUpdateStoreDto.java
@@ -1,10 +1,7 @@
 package com.example.delivery.store.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 import java.util.UUID;
 
@@ -35,6 +32,10 @@ public record ReqUpdateStoreDto(
                 regexp = "^$|^[0-9-]{9,20}$",
                 message = "전화번호 형식이 올바르지 않습니다."
         )
-        String phone
+        String phone,
+
+        @NotNull(message = "최소 주문 금액은 필수입니다.")
+        @PositiveOrZero(message = "최소 주문 금액은 0원 이상이어야 합니다.")
+        Integer minOrderAmount
 ) {
 }

--- a/src/main/java/com/example/delivery/store/presentation/dto/response/ResCreateStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/response/ResCreateStoreDto.java
@@ -31,6 +31,9 @@ public record ResCreateStoreDto(
         @Schema(description = "전화번호")
         String phone,
 
+        @Schema(description = "최소 주문 금액")
+        Integer minOrderAmount,
+
         @Schema(description = "평균 평점")
         BigDecimal averageRating,
 
@@ -52,6 +55,7 @@ public record ResCreateStoreDto(
                 store.getName(),
                 store.getAddress(),
                 store.getPhone(),
+                store.getMinOrderAmount(),
                 store.getAverageRating(),
                 store.isHidden(),
                 store.getCreatedAt(),

--- a/src/main/java/com/example/delivery/store/presentation/dto/response/ResGetStoreDto.java
+++ b/src/main/java/com/example/delivery/store/presentation/dto/response/ResGetStoreDto.java
@@ -31,6 +31,9 @@ public record ResGetStoreDto(
         @Schema(description = "전화번호")
         String phone,
 
+        @Schema(description = "최소 주문 금액")
+        Integer minOrderAmount,
+
         @Schema(description = "평균 평점")
         BigDecimal averageRating,
 
@@ -58,6 +61,7 @@ public record ResGetStoreDto(
                 store.getName(),
                 store.getAddress(),
                 store.getPhone(),
+                store.getMinOrderAmount(),
                 store.getAverageRating(),
                 store.isHidden(),
                 store.getCreatedAt(),

--- a/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
+++ b/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
@@ -75,7 +75,7 @@ class StoreServiceV1Test {
             UUID areaId = UUID.randomUUID();
 
             ReqCreateStoreDto request = new ReqCreateStoreDto(
-                    categoryId, areaId, "광화문 한식당", "서울 종로구 세종대로 1", "02-1234-5678"
+                    categoryId, areaId, "광화문 한식당", "서울 종로구 세종대로 1", "02-1234-5678", 15000
             );
 
             StoreEntity saved = createStoreEntity(
@@ -96,6 +96,7 @@ class StoreServiceV1Test {
             assertThat(result.categoryId()).isEqualTo(categoryId);
             assertThat(result.areaId()).isEqualTo(areaId);
             assertThat(result.name()).isEqualTo("광화문 한식당");
+            assertThat(result.minOrderAmount()).isEqualTo(15000);
             assertThat(result.isHidden()).isFalse();
 
             ArgumentCaptor<StoreEntity> captor = ArgumentCaptor.forClass(StoreEntity.class);
@@ -106,6 +107,7 @@ class StoreServiceV1Test {
             assertThat(captured.getName()).isEqualTo("광화문 한식당");
             assertThat(captured.getAddress()).isEqualTo("서울 종로구 세종대로 1");
             assertThat(captured.getPhone()).isEqualTo("02-1234-5678");
+            assertThat(captured.getMinOrderAmount()).isEqualTo(15000);
         }
 
         @Test
@@ -117,7 +119,7 @@ class StoreServiceV1Test {
             UUID areaId = UUID.randomUUID();
 
             ReqCreateStoreDto request = new ReqCreateStoreDto(
-                    categoryId, areaId, "  광화문 한식당  ", "  서울 종로구  ", "   "
+                    categoryId, areaId, "  광화문 한식당  ", "  서울 종로구  ", "   ", 15000
             );
 
             StoreEntity saved = createStoreEntity(
@@ -140,6 +142,7 @@ class StoreServiceV1Test {
             assertThat(captured.getName()).isEqualTo("광화문 한식당");
             assertThat(captured.getAddress()).isEqualTo("서울 종로구");
             assertThat(captured.getPhone()).isNull();
+            assertThat(captured.getMinOrderAmount()).isEqualTo(15000);
         }
 
         @Test
@@ -151,7 +154,7 @@ class StoreServiceV1Test {
             UUID areaId = UUID.randomUUID();
 
             ReqCreateStoreDto request = new ReqCreateStoreDto(
-                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678"
+                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678", 15000
             );
 
             given(categoryRepository.findById(categoryId)).willReturn(Optional.empty());
@@ -172,7 +175,7 @@ class StoreServiceV1Test {
             UUID areaId = UUID.randomUUID();
 
             ReqCreateStoreDto request = new ReqCreateStoreDto(
-                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678"
+                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678", 15000
             );
 
             given(categoryRepository.findById(categoryId)).willReturn(Optional.of(createCategoryEntity(categoryId)));
@@ -194,7 +197,7 @@ class StoreServiceV1Test {
             UUID areaId = UUID.randomUUID();
 
             ReqCreateStoreDto request = new ReqCreateStoreDto(
-                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678"
+                    categoryId, areaId, "광화문 한식당", "서울", "02-1234-5678", 15000
             );
 
             StoreEntity existing = createStoreEntity(
@@ -371,7 +374,7 @@ class StoreServiceV1Test {
             setField(store, "id", storeId);
 
             ReqUpdateStoreDto request = new ReqUpdateStoreDto(
-                    categoryId, areaId, "광화문 리뉴얼", "서울 종로구 2", "02-2222-2222"
+                    categoryId, areaId, "광화문 리뉴얼", "서울 종로구 2", "02-2222-2222", 20000
             );
             UserPrincipal principal = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
 
@@ -388,6 +391,7 @@ class StoreServiceV1Test {
             assertThat(store.getName()).isEqualTo("광화문 리뉴얼");
             assertThat(store.getAddress()).isEqualTo("서울 종로구 2");
             assertThat(store.getPhone()).isEqualTo("02-2222-2222");
+            assertThat(store.getMinOrderAmount()).isEqualTo(20000);
         }
 
         @Test
@@ -405,7 +409,7 @@ class StoreServiceV1Test {
             setField(store, "id", storeId);
 
             ReqUpdateStoreDto request = new ReqUpdateStoreDto(
-                    categoryId, areaId, "새이름", "서울", null
+                    categoryId, areaId, "새이름", "서울", null, 20000
             );
             UserPrincipal manager = new UserPrincipal(UUID.randomUUID(), "mng01", UserRole.MANAGER);
 
@@ -436,7 +440,7 @@ class StoreServiceV1Test {
             setField(store, "id", storeId);
 
             ReqUpdateStoreDto request = new ReqUpdateStoreDto(
-                    categoryId, areaId, "광화문 한식당", "서울 바뀐 주소", "02-9999-9999"
+                    categoryId, areaId, "광화문 한식당", "서울 바뀐 주소", "02-9999-9999", 20000
             );
             UserPrincipal principal = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
 
@@ -466,7 +470,7 @@ class StoreServiceV1Test {
             setField(store, "id", storeId);
 
             ReqUpdateStoreDto request = new ReqUpdateStoreDto(
-                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null
+                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null, 20000
             );
             UserPrincipal other = new UserPrincipal(otherOwnerId, "other01", UserRole.OWNER);
 
@@ -490,7 +494,7 @@ class StoreServiceV1Test {
             setField(store, "id", storeId);
 
             ReqUpdateStoreDto request = new ReqUpdateStoreDto(
-                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null
+                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null, 20000
             );
             UserPrincipal customer = new UserPrincipal(UUID.randomUUID(), "cust01", UserRole.CUSTOMER);
 
@@ -507,7 +511,7 @@ class StoreServiceV1Test {
             // given
             UUID storeId = UUID.randomUUID();
             ReqUpdateStoreDto request = new ReqUpdateStoreDto(
-                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null
+                    UUID.randomUUID(), UUID.randomUUID(), "새이름", "서울", null, 20000
             );
             UserPrincipal principal = new UserPrincipal(UUID.randomUUID(), "owner01", UserRole.OWNER);
 
@@ -537,7 +541,7 @@ class StoreServiceV1Test {
             );
 
             ReqUpdateStoreDto request = new ReqUpdateStoreDto(
-                    categoryId, areaId, "새이름", "서울", null
+                    categoryId, areaId, "새이름", "서울", null, 20000
             );
             UserPrincipal principal = new UserPrincipal(ownerId, "owner01", UserRole.OWNER);
 
@@ -746,6 +750,7 @@ class StoreServiceV1Test {
                 .name(name)
                 .address(address)
                 .phone(phone)
+                .minOrderAmount(15000)
                 .build();
 
         setField(store, "id", UUID.randomUUID());

--- a/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
+++ b/src/test/java/com/example/delivery/store/application/service/StoreServiceV1Test.java
@@ -340,6 +340,7 @@ class StoreServiceV1Test {
             assertThat(result.storeId()).isEqualTo(storeId);
             assertThat(result.name()).isEqualTo("광화문 한식당");
             assertThat(result.phone()).isEqualTo("02-1234-5678");
+            assertThat(result.minOrderAmount()).isEqualTo(15000);
         }
 
         @Test
@@ -423,6 +424,7 @@ class StoreServiceV1Test {
 
             // then
             assertThat(result.name()).isEqualTo("새이름");
+            assertThat(result.minOrderAmount()).isEqualTo(20000);
         }
 
         @Test


### PR DESCRIPTION
## 관련 이슈
Close #50 


## 작업 내용

- Store 도메인에 최소 주문 금액 필드 `minOrderAmount`를 추가했습니다.
- `p_store.min_order_amount` 컬럼 매핑을 추가했습니다.
- 가게 생성/수정 요청 DTO에 최소 주문 금액 입력값을 추가했습니다.
- 가게 생성/수정 응답 DTO에 최소 주문 금액을 포함했습니다.
- 최소 주문 금액은 필수값이며 0원 이상만 허용하도록 Validation을 적용했습니다.

## 변경 사항

### StoreEntity

- `minOrderAmount` 필드 추가
- 생성자 Builder에 `minOrderAmount` 추가
- `update()` 메서드에 `minOrderAmount` 갱신 로직 추가

### DTO

- `ReqCreateStoreDto.minOrderAmount` 추가
- `ReqUpdateStoreDto.minOrderAmount` 추가
- `ResCreateStoreDto.minOrderAmount` 추가
- `ResGetStoreDto.minOrderAmount` 추가

### Service

- Store 생성 시 `minOrderAmount` 저장
- Store 수정 시 `minOrderAmount` 갱신

## 검증 내용

- [x] Store 생성 시 최소 주문 금액 저장 확인
- [x] Store 수정 시 최소 주문 금액 변경 확인
- [x] 최소 주문 금액이 null이면 Validation 실패
- [x] 최소 주문 금액이 음수이면 Validation 실패
- [x] 기존 Store 조회 응답에 `minOrderAmount` 포함 확인