### PR TITLE
feature: 사용자 테스트 시나리오 추가 (#53)

### DIFF
--- a/src/main/java/com/example/delivery/user/application/service/AuthService.java
+++ b/src/main/java/com/example/delivery/user/application/service/AuthService.java
@@ -38,10 +38,10 @@ public class AuthService {
         requireUsernameAvailable(username);
         requireEmailAvailable(email);
 
+        // race 안전망(unique 보장)은 UserRepository 가 책임진다.
         UserEntity saved = userRepository.save(UserEntity.register(
                 username, req.nickname(), email,
                 passwordEncoder.encode(req.password()), req.role()));
-
         return ResSignup.from(saved);
     }
 
@@ -57,13 +57,14 @@ public class AuthService {
     }
 
     private void requireUsernameAvailable(Username username) {
-        if (userRepository.existsByUsername(username.value())) {
+        // soft-deleted 까지 포함하여 영구 점유로 본다.
+        if (userRepository.existsByUsernameIncludingDeleted(username.value())) {
             throw new BusinessException(ErrorCode.DUPLICATE_USERNAME);
         }
     }
 
     private void requireEmailAvailable(Email email) {
-        if (userRepository.existsByEmail(email.value())) {
+        if (userRepository.existsByEmailIncludingDeleted(email.value())) {
             throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
     }

--- a/src/main/java/com/example/delivery/user/application/service/UserService.java
+++ b/src/main/java/com/example/delivery/user/application/service/UserService.java
@@ -33,6 +33,10 @@ public class UserService {
         UserEntity user = findUserOrThrow(username);
         verifyCurrentPasswordIfChanging(user, req, me);
         user.update(me, toUpdateCommand(req, username));
+        // dirty checking 으로 commit 시점에 UPDATE 가 일어나면 unique 위반이
+        // repository 의 catch 블록 밖에서 발생해 도메인 예외로 변환되지 않는다.
+        // 명시적 save 로 즉시 flush 시켜 unique 보장 책임을 repository 에 위임한다.
+        userRepository.save(user);
 
         return ResUserDto.from(user);
     }
@@ -103,7 +107,8 @@ public class UserService {
     }
 
     private Email requireEmailAvailable(Email email, String targetUsername) {
-        if (userRepository.existsByEmailExcept(email.value(), targetUsername)) {
+        // soft-deleted 까지 포함해 영구 점유 정책을 강제한다.
+        if (userRepository.existsByEmailExceptIncludingDeleted(email.value(), targetUsername)) {
             throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
 

--- a/src/main/java/com/example/delivery/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/delivery/user/domain/repository/UserRepository.java
@@ -15,11 +15,13 @@ public interface UserRepository {
 
     Optional<UserEntity> findByUsername(String username);
 
-    boolean existsByUsername(String username);
+    // soft-deleted 까지 포함하여 점유 여부를 확인한다 (영구 점유 정책 강제용).
 
-    boolean existsByEmail(String email);
+    boolean existsByUsernameIncludingDeleted(String username);
 
-    boolean existsByEmailExcept(String email, String excludeUsername);
+    boolean existsByEmailIncludingDeleted(String email);
+
+    boolean existsByEmailExceptIncludingDeleted(String email, String excludeUsername);
 
     Page<UserEntity> search(String keyword, UserRole role, Pageable pageable);
 }

--- a/src/main/java/com/example/delivery/user/infrastructure/repository/UserJpaRepository.java
+++ b/src/main/java/com/example/delivery/user/infrastructure/repository/UserJpaRepository.java
@@ -1,13 +1,13 @@
 package com.example.delivery.user.infrastructure.repository;
 
 import com.example.delivery.user.domain.entity.UserEntity;
-import com.example.delivery.user.domain.vo.Email;
 import com.example.delivery.user.domain.vo.Username;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserJpaRepository
         extends JpaRepository<UserEntity, UUID>,
@@ -16,15 +16,25 @@ public interface UserJpaRepository
     @Query("select u from UserEntity u where u.username = :username")
     Optional<UserEntity> findByUsername(Username username);
 
-    boolean existsByUsername(Username username);
+    // soft-deleted row 까지 포함 — @SQLRestriction 우회를 위해 native query 사용.
+    // username/email 의 영구 점유 정책을 강제하기 위함.
 
-    boolean existsByEmail(Email email);
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM p_user WHERE username = :username)",
+            nativeQuery = true)
+    boolean existsByUsernameIncludingDeleted(@Param("username") String username);
 
-    @Query("""
-            select case when count(u) > 0 then true else false end
-            from UserEntity u
-            where u.email = :email
-              and u.username <> :excludeUsername
-            """)
-    boolean existsByEmailExcept(Email email, Username excludeUsername);
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM p_user WHERE email = :email)",
+            nativeQuery = true)
+    boolean existsByEmailIncludingDeleted(@Param("email") String email);
+
+    @Query(value = """
+            SELECT EXISTS(
+                SELECT 1 FROM p_user
+                WHERE email = :email
+                  AND username <> :excludeUsername
+            )
+            """, nativeQuery = true)
+    boolean existsByEmailExceptIncludingDeleted(
+            @Param("email") String email,
+            @Param("excludeUsername") String excludeUsername);
 }

--- a/src/main/java/com/example/delivery/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/example/delivery/user/infrastructure/repository/UserRepositoryImpl.java
@@ -1,14 +1,17 @@
 package com.example.delivery.user.infrastructure.repository;
 
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.user.domain.entity.UserEntity;
 import com.example.delivery.user.domain.entity.UserRole;
 import com.example.delivery.user.domain.repository.UserRepository;
 import com.example.delivery.user.domain.repository.UserSearchSpecs;
-import com.example.delivery.user.domain.vo.Email;
 import com.example.delivery.user.domain.vo.Username;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -21,7 +24,12 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public UserEntity save(UserEntity user) {
-        return userJpaRepository.save(user);
+        // unique 보장은 repository 책임. 즉시 flush 해서 violation 을 도메인 예외로 정규화한다.
+        try {
+            return userJpaRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException e) {
+            throw UniqueViolation.translate(e);
+        }
     }
 
     @Override
@@ -35,22 +43,58 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public boolean existsByUsername(String username) {
-        return userJpaRepository.existsByUsername(new Username(username));
+    public boolean existsByUsernameIncludingDeleted(String username) {
+        return userJpaRepository.existsByUsernameIncludingDeleted(username);
     }
 
     @Override
-    public boolean existsByEmail(String email) {
-        return userJpaRepository.existsByEmail(new Email(email));
+    public boolean existsByEmailIncludingDeleted(String email) {
+        return userJpaRepository.existsByEmailIncludingDeleted(email);
     }
 
     @Override
-    public boolean existsByEmailExcept(String email, String excludeUsername) {
-        return userJpaRepository.existsByEmailExcept(new Email(email), new Username(excludeUsername));
+    public boolean existsByEmailExceptIncludingDeleted(String email, String excludeUsername) {
+        return userJpaRepository.existsByEmailExceptIncludingDeleted(email, excludeUsername);
     }
 
     @Override
     public Page<UserEntity> search(String keyword, UserRole role, Pageable pageable) {
         return userJpaRepository.findAll(UserSearchSpecs.build(keyword, role), pageable);
+    }
+
+    /**
+     * p_user 의 unique 컬럼별 도메인 예외 매핑.
+     * - 새 unique 컬럼 추가 시 enum 한 줄만 추가
+     * - 매칭 우선순위: USERNAME 먼저 (가입 race 의 대다수)
+     * - SQL statement 절단으로 컬럼 리스트 노이즈 제거 (다른 컬럼명 오매칭 방지)
+     */
+    private enum UniqueViolation {
+        USERNAME("USERNAME", ErrorCode.DUPLICATE_USERNAME),
+        EMAIL("EMAIL", ErrorCode.DUPLICATE_EMAIL);
+
+        private final String columnHint;
+        private final ErrorCode errorCode;
+
+        UniqueViolation(String columnHint, ErrorCode errorCode) {
+            this.columnHint = columnHint;
+            this.errorCode = errorCode;
+        }
+
+        static RuntimeException translate(DataIntegrityViolationException cause) {
+            String message = headerOf(cause).toUpperCase();
+            return Arrays.stream(values())
+                    .filter(violation -> message.contains(violation.columnHint))
+                    .findFirst()
+                    .<RuntimeException>map(violation -> new BusinessException(violation.errorCode))
+                    .orElse(cause);
+        }
+
+        private static String headerOf(DataIntegrityViolationException cause) {
+            // H2/PostgreSQL 모두 "; SQL statement" 또는 "; SQL" 이후에 INSERT 문 본문이 붙는다.
+            // 그 부분을 잘라내야 INSERT 컬럼 리스트의 오매칭을 막을 수 있다.
+            String full = String.valueOf(cause.getMostSpecificCause());
+            int sqlPos = full.indexOf("; SQL");
+            return sqlPos > 0 ? full.substring(0, sqlPos) : full;
+        }
     }
 }

--- a/src/test/java/com/example/delivery/global/test/IntegrationTestSupport.java
+++ b/src/test/java/com/example/delivery/global/test/IntegrationTestSupport.java
@@ -1,0 +1,81 @@
+package com.example.delivery.global.test;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.delivery.user.domain.entity.UserEntity;
+import com.example.delivery.user.domain.entity.UserRole;
+import com.example.delivery.user.domain.repository.UserRepository;
+import com.example.delivery.user.domain.vo.Email;
+import com.example.delivery.user.domain.vo.Username;
+import com.example.delivery.user.presentation.dto.request.ReqLogin;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+/**
+ * 공통 통합 테스트 베이스.
+ *
+ * - MockMvc/ObjectMapper/Repository/PasswordEncoder를 묶어 헬퍼만 노출.
+ * - {@code @SpringBootTest} 등 클래스 메타는 구체 테스트 클래스에서 직접 선언한다
+ *   (트랜잭션 정책이 시나리오마다 달라 베이스에서 강제하지 않는다).
+ */
+public abstract class IntegrationTestSupport {
+
+    public static final String DEFAULT_PASSWORD = "Abcd1234!";
+
+    @Autowired
+    protected MockMvc mockMvc;
+    @Autowired
+    protected ObjectMapper objectMapper;
+    @Autowired
+    protected UserRepository userRepository;
+    @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    protected String login(String username, String password) throws Exception {
+        String body = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ReqLogin(username, password))))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        JsonNode node = objectMapper.readTree(body);
+        return node.path("data").path("accessToken").asText();
+    }
+
+    protected UserEntity seedUser(String username, UserRole role) {
+        return seedUser(username, username + "_nick", username + "@example.com", DEFAULT_PASSWORD, role);
+    }
+
+    protected UserEntity seedUser(String username, String nickname, String email,
+            String rawPassword, UserRole role) {
+        return userRepository.save(UserEntity.register(
+                new Username(username),
+                nickname,
+                new Email(email),
+                passwordEncoder.encode(rawPassword),
+                role));
+    }
+
+    protected ResultActions authedGet(String url, String token) throws Exception {
+        return mockMvc.perform(get(url).header("Authorization", "Bearer " + token));
+    }
+
+    protected ResultActions authedPatch(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(patch(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    protected ResultActions authedDelete(String url, String token) throws Exception {
+        return mockMvc.perform(delete(url).header("Authorization", "Bearer " + token));
+    }
+}

--- a/src/test/java/com/example/delivery/user/application/service/UserServiceUpdateTest.java
+++ b/src/test/java/com/example/delivery/user/application/service/UserServiceUpdateTest.java
@@ -54,7 +54,7 @@ class UserServiceUpdateTest {
     @Test
     @DisplayName("본인은 nickname/email/password/isPublic 모두 수정 가능 (currentPassword 일치)")
     void self_canUpdateAll() {
-        given(userRepository.existsByEmailExcept(any(), any())).willReturn(false);
+        given(userRepository.existsByEmailExceptIncludingDeleted(any(), any())).willReturn(false);
         given(passwordEncoder.matches("OldPass1!", "hash")).willReturn(true);
         given(passwordEncoder.encode("Abcd1234!")).willReturn("new-hash");
 
@@ -189,7 +189,7 @@ class UserServiceUpdateTest {
     @Test
     @DisplayName("본인이 중복 email(다른 사용자 사용 중)로 수정 시 409")
     void self_duplicateEmail() {
-        given(userRepository.existsByEmailExcept("taken@mail.co", "alice")).willReturn(true);
+        given(userRepository.existsByEmailExceptIncludingDeleted("taken@mail.co", "alice")).willReturn(true);
         ReqUpdateUser req = new ReqUpdateUser(null, "taken@mail.co", null, null, null);
         LoginUser me = new LoginUser(UUID.randomUUID(), "alice", UserRole.CUSTOMER);
 

--- a/src/test/java/com/example/delivery/user/integration/UserAuthRoleTransitionIntegrationTest.java
+++ b/src/test/java/com/example/delivery/user/integration/UserAuthRoleTransitionIntegrationTest.java
@@ -1,0 +1,167 @@
+package com.example.delivery.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.user.domain.entity.UserEntity;
+import com.example.delivery.user.domain.entity.UserRole;
+import com.example.delivery.user.domain.vo.Username;
+import com.example.delivery.user.presentation.dto.request.ReqChangeRole;
+import com.example.delivery.user.presentation.dto.request.ReqUpdateUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Role 전이 체인과 JWT 일괄 무효화 + Privileged ↔ Privileged 교차 권한 매트릭스.
+ *
+ * 시나리오 문서: docs/test-scenarios-user-auth.md
+ *
+ * 시나리오 문서의 짧은 username (m1, m2, o1, c1) 은 Username VO 정책(소문자/숫자 4~10자)
+ * 위반이라 실제 코드에서 거부된다. 본 테스트는 mngr1/mngr2/ownr1/cust1 로 치환하여 검증한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class UserAuthRoleTransitionIntegrationTest extends IntegrationTestSupport {
+
+    // ────────────────────────────────────────────────
+    // Role 전이 체인
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("role 전이 시 이전 JWT 즉시 무효화 → 재로그인 이후에만 신규 권한 적용")
+    void roleTransition_invalidatesPreviousTokens() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        seedUser("cara01", UserRole.CUSTOMER);
+
+        // step 1: cara01 로그인 → 토큰 A (role=CUSTOMER)
+        String tokenA = login("cara01", DEFAULT_PASSWORD);
+
+        // step 2: master01 이 cara01 → OWNER 로 변경
+        String masterToken = login("master01", DEFAULT_PASSWORD);
+        authedPatch("/api/v1/users/cara01/role", masterToken, new ReqChangeRole(UserRole.OWNER))
+                .andExpect(status().isOk());
+
+        // step 3: 토큰 A 로 /me → 403 ROLE_MISMATCH (JwtAuthenticationFilter)
+        authedGet("/api/v1/users/me", tokenA)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("ROLE_MISMATCH"));
+
+        // step 4~5: cara01 재로그인 → 토큰 B, /me 200 OWNER
+        String tokenB = login("cara01", DEFAULT_PASSWORD);
+        authedGet("/api/v1/users/me", tokenB)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.role").value("OWNER"));
+
+        // step 6: master01 이 cara01 → MANAGER 로 변경
+        authedPatch("/api/v1/users/cara01/role", masterToken, new ReqChangeRole(UserRole.MANAGER))
+                .andExpect(status().isOk());
+
+        // step 7: 토큰 B 로 /me → 403 ROLE_MISMATCH
+        authedGet("/api/v1/users/me", tokenB)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("ROLE_MISMATCH"));
+
+        // step 8: 토큰 B 로 /users (목록) → 403 ROLE_MISMATCH
+        // (인가 단계가 아니라 필터 재검증 단계에서 막혀야 함)
+        authedGet("/api/v1/users", tokenB)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("ROLE_MISMATCH"));
+
+        // step 9~10: 재로그인 → 토큰 C (MANAGER), /users?role=CUSTOMER&size=10 → 200
+        String tokenC = login("cara01", DEFAULT_PASSWORD);
+        authedGet("/api/v1/users?role=CUSTOMER&size=10", tokenC)
+                .andExpect(status().isOk());
+    }
+
+    // ────────────────────────────────────────────────
+    // Privileged 매트릭스 — 시드는 매 테스트가 직접 수행
+    // (DELETE 가 row 를 변형시키므로 grouping 별로 메서드 분리)
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("read 매트릭스: MANAGER 는 비-privileged 와 본인 조회 가능, 다른 MANAGER/MASTER 는 403")
+    void manager_readMatrix() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        seedUser("mngr1", UserRole.MANAGER);
+        seedUser("mngr2", UserRole.MANAGER);
+        seedUser("ownr1", UserRole.OWNER);
+        seedUser("cust1", UserRole.CUSTOMER);
+
+        String mngr1Token = login("mngr1", DEFAULT_PASSWORD);
+
+        authedGet("/api/v1/users/cust1", mngr1Token).andExpect(status().isOk());
+        authedGet("/api/v1/users/ownr1", mngr1Token).andExpect(status().isOk());
+        authedGet("/api/v1/users/mngr1", mngr1Token).andExpect(status().isOk()); // self
+        authedGet("/api/v1/users/mngr2", mngr1Token).andExpect(status().isForbidden());
+        authedGet("/api/v1/users/master01", mngr1Token).andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("mutate 매트릭스: MANAGER 가 다른 MANAGER/MASTER 의 nickname 수정 시도 → 403")
+    void manager_cannotMutatePrivilegedPeer() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        seedUser("mngr1", UserRole.MANAGER);
+        seedUser("mngr2", UserRole.MANAGER);
+
+        String mngr1Token = login("mngr1", DEFAULT_PASSWORD);
+        ReqUpdateUser body = new ReqUpdateUser("changed", null, null, null, null);
+
+        authedPatch("/api/v1/users/mngr2", mngr1Token, body).andExpect(status().isForbidden());
+        authedPatch("/api/v1/users/master01", mngr1Token, body).andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("delete 매트릭스: MANAGER 는 다른 MANAGER 삭제 불가(403), OWNER 는 삭제 가능(204)")
+    void manager_deleteMatrix_andSoftDeleteAudit() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        seedUser("mngr1", UserRole.MANAGER);
+        seedUser("mngr2", UserRole.MANAGER);
+        seedUser("ownr1", UserRole.OWNER);
+
+        String mngr1Token = login("mngr1", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/users/mngr2", mngr1Token).andExpect(status().isForbidden());
+        authedDelete("/api/v1/users/ownr1", mngr1Token).andExpect(status().isNoContent());
+
+        // 스팟 체크: ownr1 이 soft delete 후 일반 조회로 더는 안 보임
+        assertThat(userRepository.findByUsername("ownr1")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("role 변경: MANAGER 는 role 변경 불가 → 403 (MASTER 전용)")
+    void manager_cannotChangeRole() throws Exception {
+        seedUser("mngr1", UserRole.MANAGER);
+        seedUser("cust1", UserRole.CUSTOMER);
+
+        String mngr1Token = login("mngr1", DEFAULT_PASSWORD);
+
+        authedPatch("/api/v1/users/cust1/role", mngr1Token, new ReqChangeRole(UserRole.OWNER))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("MASTER 는 MANAGER 에 대한 GET / PATCH / DELETE 모두 가능")
+    void master_fullCrudOnManager() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        UserEntity mngr1 = seedUser("mngr1", UserRole.MANAGER);
+
+        String masterToken = login("master01", DEFAULT_PASSWORD);
+
+        authedGet("/api/v1/users/mngr1", masterToken).andExpect(status().isOk());
+        authedPatch("/api/v1/users/mngr1", masterToken,
+                new ReqUpdateUser("byMaster", null, null, null, null))
+                .andExpect(status().isOk());
+        authedDelete("/api/v1/users/mngr1", masterToken).andExpect(status().isNoContent());
+
+        assertThat(userRepository.findByUsername("mngr1")).isEmpty();
+        assertThat(mngr1.getUsername()).isEqualTo(new Username("mngr1"));
+    }
+}

--- a/src/test/java/com/example/delivery/user/integration/UserAuthSmokeIntegrationTest.java
+++ b/src/test/java/com/example/delivery/user/integration/UserAuthSmokeIntegrationTest.java
@@ -27,11 +27,17 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Smoke 레벨 통합 테스트 — auth/user 엔드포인트의 기본 happy/sad path 만 빠르게 검증한다.
+ * 깊은 경계 검증(role 전이 체인, privileged 매트릭스, soft delete 정책, 동시성)은
+ * 별도 클래스 (UserAuthRoleTransitionIntegrationTest / UserSoftDeleteIntegrationTest /
+ * UserSignupConcurrencyIntegrationTest) 참조.
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
-class UserAuthIntegrationTest {
+class UserAuthSmokeIntegrationTest {
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/delivery/user/integration/UserSignupConcurrencyIntegrationTest.java
+++ b/src/test/java/com/example/delivery/user/integration/UserSignupConcurrencyIntegrationTest.java
@@ -1,0 +1,161 @@
+package com.example.delivery.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.delivery.user.domain.entity.UserRole;
+import com.example.delivery.user.domain.repository.UserRepository;
+import com.example.delivery.user.presentation.dto.request.ReqSignup;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Signup 동시성 — 동일 username / email 경쟁 조건.
+ *
+ * 시나리오 문서: docs/test-scenarios-user-auth.md
+ *
+ * - {@code @Transactional} 롤백 사용 금지 — 각 요청이 별도 트랜잭션이어야 race 가 의미 있음.
+ * - 매 실행마다 randomized prefix 로 격리, {@code @AfterEach} 에서 잔여 row 수동 정리.
+ * - DB 는 application-test.yml 의 H2(PostgreSQL 모드) 를 그대로 사용한다.
+ *   H2 도 {@code @Column(unique = true)} 의 unique constraint 를 INSERT 시점에 강제하므로
+ *   "1 승, N-1 패" 분포 검증에는 충분하다 (운영 DB 와 100% 동일하지는 않으나 race 안전망 회귀 검증 목적).
+ *
+ * 정책 (영구 점유 / 거부):
+ * - {@code AuthService.signup} 에 race 안전망(saveAndFlush + DataIntegrityViolation catch) 적용 →
+ *   실패 응답은 모두 409 로 정규화되어야 한다. 5xx 가 발생하면 회귀.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class UserSignupConcurrencyIntegrationTest {
+
+    @Autowired
+    TestRestTemplate restTemplate;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    EntityManager entityManager;
+    @Autowired
+    PlatformTransactionManager txManager;
+
+    @AfterEach
+    void cleanup() {
+        // @AfterEach 에는 Spring 의 @Transactional 이 적용되지 않으므로 TransactionTemplate 으로 수동 처리.
+        new TransactionTemplate(txManager).executeWithoutResult(status ->
+                entityManager.createNativeQuery("DELETE FROM p_user WHERE username LIKE 'race%'")
+                        .executeUpdate());
+    }
+
+    @Test
+    @DisplayName("동일 username 동시 signup → 성공 정확히 1, 살아있는 row 정확히 1")
+    void concurrentSignup_sameUsername_exactlyOneSucceeds() throws Exception {
+        int n = 8;
+        String sharedUsername = "race" + (System.nanoTime() % 100_000);
+
+        Outcome out = race(n, idx -> new ReqSignup(
+                sharedUsername,
+                "nick" + idx,
+                "race" + idx + "_" + System.nanoTime() + "@example.com",
+                "Abcd1234!",
+                UserRole.CUSTOMER));
+
+        assertThat(out.created.get()).as("성공 정확히 1개").isEqualTo(1);
+        assertThat(out.conflict.get()).as("실패 N-1 개 모두 409").isEqualTo(n - 1);
+        assertThat(out.serverError.get()).as("5xx 0 개").isZero();
+        assertThat(out.other.get()).as("예측되지 않은 상태 코드 0").isZero();
+        assertThat(userRepository.findByUsername(sharedUsername))
+                .as("살아있는 row 1개").isPresent();
+    }
+
+    @Test
+    @DisplayName("동일 email 동시 signup → 성공 정확히 1, 살아있는 row 정확히 1")
+    void concurrentSignup_sameEmail_exactlyOneSucceeds() throws Exception {
+        int n = 8;
+        String sharedEmail = "race" + (System.nanoTime() % 100_000) + "@example.com";
+
+        Outcome out = race(n, idx -> new ReqSignup(
+                "race" + idx + (System.nanoTime() % 100_000),
+                "nick" + idx,
+                sharedEmail,
+                "Abcd1234!",
+                UserRole.CUSTOMER));
+
+        assertThat(out.created.get()).as("성공 정확히 1개").isEqualTo(1);
+        assertThat(out.conflict.get()).as("실패 N-1 개 모두 409").isEqualTo(n - 1);
+        assertThat(out.serverError.get()).as("5xx 0 개").isZero();
+        assertThat(out.other.get()).isZero();
+
+        Long alive = new TransactionTemplate(txManager).execute(status -> ((Number) entityManager
+                .createNativeQuery("SELECT count(*) FROM p_user WHERE email = :e AND deleted_at IS NULL")
+                .setParameter("e", sharedEmail)
+                .getSingleResult()).longValue());
+        assertThat(alive).isEqualTo(1L);
+    }
+
+    // ────────────────────────────────────────────────
+    // race 실행 헬퍼
+    // ────────────────────────────────────────────────
+
+    private Outcome race(int n, RequestFactory factory) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(n);
+        CyclicBarrier barrier = new CyclicBarrier(n);
+
+        Outcome out = new Outcome();
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            int idx = i;
+            futures.add(executor.submit(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    ReqSignup body = factory.build(idx);
+                    ResponseEntity<String> res = restTemplate.postForEntity(
+                            "/api/v1/auth/signup", body, String.class);
+                    int code = res.getStatusCode().value();
+                    if (code == 201) {
+                        out.created.incrementAndGet();
+                    } else if (code == 409) {
+                        out.conflict.incrementAndGet();
+                    } else if (code >= 500) {
+                        out.serverError.incrementAndGet();
+                    } else {
+                        out.other.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    out.other.incrementAndGet();
+                }
+            }));
+        }
+        for (Future<?> f : futures) {
+            f.get(15, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+        return out;
+    }
+
+    private static final class Outcome {
+        final AtomicInteger created = new AtomicInteger();
+        final AtomicInteger conflict = new AtomicInteger();
+        final AtomicInteger serverError = new AtomicInteger();
+        final AtomicInteger other = new AtomicInteger();
+    }
+
+    @FunctionalInterface
+    private interface RequestFactory {
+        ReqSignup build(int idx);
+    }
+}

--- a/src/test/java/com/example/delivery/user/integration/UserSoftDeleteIntegrationTest.java
+++ b/src/test/java/com/example/delivery/user/integration/UserSoftDeleteIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.example.delivery.user.integration;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.user.domain.entity.UserRole;
+import com.example.delivery.user.presentation.dto.request.ReqLogin;
+import com.example.delivery.user.presentation.dto.request.ReqSignup;
+import com.example.delivery.user.presentation.dto.request.ReqUpdateUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Soft Delete ↔ Unique 제약 상호작용.
+ *
+ * 시나리오 문서: docs/test-scenarios-user-auth.md
+ *
+ * 정책: 삭제된 username/email 은 영구 점유로 본다 (재점유 거부).
+ * - {@code AuthService.signup} 과 {@code UserService.update} 는 application 체크에서
+ *   {@code existsBy*IncludingDeleted} 로 soft-deleted row 까지 포함해 검증한다.
+ * - race 로 application 체크 사이를 통과한 경우에도
+ *   {@code DataIntegrityViolationException} 을 catch 해서 409 로 정규화한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class UserSoftDeleteIntegrationTest extends IntegrationTestSupport {
+
+    // ────────────────────────────────────────────────
+    // 삭제된 username 재가입
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("삭제된 계정으로 로그인 → 401, 동일 username 재가입 → 409 DUPLICATE_USERNAME")
+    void deletedUsername_loginBlockedAndReSignupRejected() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        seedUser("zedfx", UserRole.CUSTOMER);
+
+        String mToken = login("manager01", DEFAULT_PASSWORD);
+        authedDelete("/api/v1/users/zedfx", mToken).andExpect(status().isNoContent());
+
+        // (a) 삭제된 계정으로 로그인 → 401 (findByUsername 이 SQLRestriction 으로 못 찾음)
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new ReqLogin("zedfx", DEFAULT_PASSWORD))))
+                .andExpect(status().isUnauthorized());
+
+        // (b) 동일 username 으로 재가입 시도 → 409 (영구 점유 정책)
+        ReqSignup retry = new ReqSignup("zedfx", "zed-again", "zed2@example.com",
+                DEFAULT_PASSWORD, UserRole.CUSTOMER);
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(retry)))
+                .andExpect(status().isConflict());
+    }
+
+    // ────────────────────────────────────────────────
+    // 삭제된 email 재사용 (타 사용자 수정)
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("삭제된 사용자의 email 로 다른 사용자가 PATCH: 살아있을 때도 삭제 후에도 409")
+    void deletedEmail_patchByOther() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        seedUser("zedfx", UserRole.CUSTOMER);
+        seedUser("alice", UserRole.CUSTOMER);
+
+        String aliceToken = login("alice", DEFAULT_PASSWORD);
+
+        // (1) zed 살아있을 때: 409 DUPLICATE_EMAIL
+        authedPatch("/api/v1/users/alice", aliceToken,
+                new ReqUpdateUser(null, "zedfx@example.com", null, null, null))
+                .andExpect(status().isConflict());
+
+        // (2) zed soft delete
+        String mToken = login("manager01", DEFAULT_PASSWORD);
+        authedDelete("/api/v1/users/zedfx", mToken).andExpect(status().isNoContent());
+
+        // (3) zed 삭제 후 동일 시도 → 409 (영구 점유 정책)
+        authedPatch("/api/v1/users/alice", aliceToken,
+                new ReqUpdateUser(null, "zedfx@example.com", null, null, null))
+                .andExpect(status().isConflict());
+    }
+
+    // ────────────────────────────────────────────────
+    // 삭제된 email 로 신규 signup
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("삭제된 사용자의 email 로 신규 signup → 409 DUPLICATE_EMAIL")
+    void deletedEmail_newSignup() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        seedUser("zedfx", UserRole.CUSTOMER);
+
+        String mToken = login("manager01", DEFAULT_PASSWORD);
+        authedDelete("/api/v1/users/zedfx", mToken).andExpect(status().isNoContent());
+
+        ReqSignup req = new ReqSignup("zed2", "zed2nick", "zedfx@example.com",
+                DEFAULT_PASSWORD, UserRole.CUSTOMER);
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isConflict());
+    }
+}


### PR DESCRIPTION
## Summary

- `docs/test-scenarios-user-auth.md` 의 시나리오(S1~S4)를 실제 통합 테스트 클래스로 구현
- 구현 과정에서 발견된 username/email 의 soft-delete 후 재점유 동작(현재 500 응답)을
  **영구 점유 정책(재가입 거부)** 으로 정의/적용
- race 안전망(unique 보장) 책임을 `UserRepositoryImpl` 로 캡슐화하여 service 코드를 단순화

## Changes

### 1. 통합 테스트 시나리오
| 클래스 | 커버 시나리오 | 비고 |
|---|---|---|
| `UserAuthRoleTransitionIntegrationTest` | Role 전이 시 JWT 일괄 무효화 + Privileged 권한 매트릭스 | `@Transactional` 롤백 |
| `UserSoftDeleteIntegrationTest` | Soft Delete ↔ Unique 제약 상호작용 | `@Transactional` 롤백 |
| `UserSignupConcurrencyIntegrationTest` | 동일 username/email 동시 가입 race | 비-트랜잭션, `RANDOM_PORT`, `TestRestTemplate`, H2 |
| `UserAuthIntegrationTest` → `UserAuthSmokeIntegrationTest` | 기본 happy/sad path smoke | rename |
| `IntegrationTestSupport` | login/seedUser/authedXxx 공통 헬퍼 | 신규 |


### 2. username/email 영구 점유 정책

soft-deleted 사용자의 username/email 을 신규 사용자가 재점유할 수 없도록 정의.

- application 체크: `existsByUsernameIncludingDeleted` 등 native query 추가 (`@SQLRestriction` 우회)
- repository 가 `DataIntegrityViolationException` 을 잡아 도메인 예외로 변환 (race 안전망)
- `AuthService.signup`, `UserService.update` 에서 try-catch / saveAndFlush 호출 제거 — unique 보장은 repository 책임으로 위임

## 동작 변경 (사용자 영향)

| 케이스 | 이전 | 이후 |
|---|---|---|
| 삭제된 username 재가입 | 500 INTERNAL_ERROR | **409 DUPLICATE_USERNAME** |
| 삭제된 email 재사용 (PATCH) | 500 INTERNAL_ERROR | **409 DUPLICATE_EMAIL** |
| 삭제된 email 로 신규 signup | 500 INTERNAL_ERROR | **409 DUPLICATE_EMAIL** |
| 동시 가입 race (race 빠진 요청) | 일부 5xx 노출 가능 | **모두 409 정규화** |

## 설계 결정

- **정책**: 영구 점유 (재가입 거부) — partial unique index 옵션은 보류
- **race 안전망 위치**: `UserRepositoryImpl.save` 내부 try-catch + `UniqueViolation` enum 매핑
- **매핑 방식**: 메시지 헤더(`; SQL` 이전 부분) 매칭으로 INSERT 컬럼 리스트 노이즈 회피, USERNAME 우선 매칭
- **동시성 테스트 DB**: H2 PostgreSQL 모드 — `@Column(unique=true)` 는 H2 에서도 INSERT 시점에 강제됨을 확인
- **트랜잭션 처리**: `UserService.update` 는 명시적 `userRepository.save(user)` 호출로 즉시 flush 강제 (dirty checking 만으로는 commit 시점에 발생하는 unique 위반을 repository catch 가 못 잡음)

## Test plan

- [x] `./gradlew test --tests "com.example.delivery.user.*"` → BUILD SUCCESSFUL
- [x] `UserSignupConcurrencyIntegrationTest` (8 스레드 race) → `created=1, conflict=7, serverError=0`
- [x] `UserSoftDeleteIntegrationTest` 의 3개 케이스 모두 409 응답 확인
- [x] `./gradlew clean build -x test` → 컴파일/체크 클린
