### PR TITLE
bug: fix DB integrity violation on FAILED payment retry

### DIFF
--- a/src/main/java/com/example/delivery/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/example/delivery/payment/application/service/PaymentServiceV1.java
@@ -10,6 +10,7 @@ import com.example.delivery.payment.infrastructure.pg.PgClient;
 import com.example.delivery.payment.infrastructure.pg.PgResponse;
 import com.example.delivery.payment.presentation.dto.request.ReqCreatePaymentDto;
 import com.example.delivery.payment.presentation.dto.response.ResPaymentDto;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,24 +51,31 @@ public class PaymentServiceV1 {
         orderRepository.findById(dto.orderId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2. 중복 결제 검증 — READY 또는 COMPLETED 상태인 결제가 이미 있으면 거부
-        paymentRepository.findByOrderId(dto.orderId())
-                .filter(p -> p.getStatus() == PaymentStatus.READY
-                          || p.getStatus() == PaymentStatus.COMPLETED)
-                .ifPresent(p -> {
-                    throw new BusinessException(ErrorCode.PAYMENT_ALREADY_PROCESSED);
-                });
+        // 2. 기존 결제 조회 — 상태별 분기
+        //    FAILED: 기존 엔티티 재사용(retry) → orderId UNIQUE 제약 충돌 방지
+        //    그 외(READY/COMPLETED/CANCELLED): 중복 결제로 거부
+        //    없음: 새 엔티티 생성
+        Optional<PaymentEntity> existingOpt = paymentRepository.findByOrderId(dto.orderId());
 
-        // 3. 결제 엔티티 생성 (초기 상태: READY)
-        PaymentEntity payment = PaymentEntity.builder()
-                .orderId(dto.orderId())
-                .amount(dto.amount())
-                .build();
+        final PaymentEntity payment;
+        if (existingOpt.isPresent()) {
+            PaymentEntity existing = existingOpt.get();
+            if (existing.getStatus() != PaymentStatus.FAILED) {
+                throw new BusinessException(ErrorCode.PAYMENT_ALREADY_PROCESSED);
+            }
+            existing.retry(dto.amount());
+            payment = existing;
+        } else {
+            payment = PaymentEntity.builder()
+                    .orderId(dto.orderId())
+                    .amount(dto.amount())
+                    .build();
+        }
 
-        // 4. PG 승인 요청 (시뮬레이션)
+        // 3. PG 승인 요청 (시뮬레이션)
         PgResponse pgResponse = pgClient.requestApproval(dto.orderId(), dto.amount());
 
-        // 5. PG 응답에 따라 상태 전이
+        // 4. PG 응답에 따라 상태 전이
         if (pgResponse.success()) {
             payment.markCompleted(pgResponse.transactionId());
             log.info("[Payment] 결제 성공 — orderId={}, txId={}", dto.orderId(), pgResponse.transactionId());
@@ -76,7 +84,7 @@ public class PaymentServiceV1 {
             log.warn("[Payment] 결제 실패 — orderId={}, reason={}", dto.orderId(), pgResponse.failReason());
         }
 
-        // 6. 최종 상태로 저장
+        // 5. 최종 상태로 저장
         PaymentEntity saved = paymentRepository.save(payment);
         return ResPaymentDto.from(saved);
     }

--- a/src/main/java/com/example/delivery/payment/domain/entity/PaymentEntity.java
+++ b/src/main/java/com/example/delivery/payment/domain/entity/PaymentEntity.java
@@ -104,4 +104,23 @@ public class PaymentEntity extends BaseEntity {
         }
         this.status = PaymentStatus.CANCELLED;
     }
+
+    /**
+     * FAILED 결제를 재시도 가능 상태로 초기화한다.
+     * 기존 레코드를 재사용하므로 orderId UNIQUE 제약 충돌이 발생하지 않는다.
+     */
+    public void retry(Integer newAmount) {
+        if (this.status != PaymentStatus.FAILED) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_STATUS,
+                    "FAILED 상태의 결제만 재시도할 수 있습니다. (현재 상태: %s)".formatted(this.status));
+        }
+        if (newAmount == null || newAmount < 0) {
+            throw new BusinessException(ErrorCode.INVALID_PAYMENT_AMOUNT,
+                    "결제 금액은 0원 이상이어야 합니다. 입력값: " + newAmount);
+        }
+        this.status = PaymentStatus.READY;
+        this.amount = newAmount;
+        this.pgTransactionId = null;
+        this.paidAt = null;
+    }
 }


### PR DESCRIPTION
FAILED 결제 재시도 시 새 엔티티를 INSERT하여 order_id UNIQUE 제약 위반으로 DataIntegrityViolationException(HTTP 500)이 발생하는 버그를 수정한다.

- PaymentEntity.retry(): FAILED 상태의 엔티티를 READY로 초기화하는 메서드 추가
- PaymentServiceV1.processPayment(): FAILED 결제 존재 시 기존 엔티티 재사용(UPDATE)으로 전환
  - READY/COMPLETED/CANCELLED 상태는 PAYMENT_ALREADY_PROCESSED 예외 처리