### PR TITLE
bug: call PG refund API on payment cancellation

### DIFF
--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     PAYMENT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다."),
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다."),
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "현재 결제 상태에서는 해당 작업을 수행할 수 없습니다."),
+    REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PG사 환불 요청이 실패했습니다. 잠시 후 다시 시도해 주세요."),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),

--- a/src/main/java/com/example/delivery/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/example/delivery/payment/application/service/PaymentServiceV1.java
@@ -105,8 +105,17 @@ public class PaymentServiceV1 {
         PaymentEntity payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        payment.cancel();   // COMPLETED → CANCELLED, 그 외 상태면 BusinessException
-        log.info("[Payment] 결제 취소 — paymentId={}", paymentId);
+        // 1. 상태 검증 + CANCELLED 전이 (COMPLETED가 아니면 BusinessException)
+        payment.cancel();
+
+        // 2. PG 환불 요청 — 실패 시 예외를 던져 트랜잭션 롤백 (CANCELLED 상태 원복)
+        PgResponse refundResponse = pgClient.requestRefund(payment.getPgTransactionId(), payment.getAmount());
+        if (!refundResponse.success()) {
+            log.warn("[Payment] 환불 실패 — paymentId={}, reason={}", paymentId, refundResponse.failReason());
+            throw new BusinessException(ErrorCode.REFUND_FAILED);
+        }
+
+        log.info("[Payment] 결제 취소 완료 — paymentId={}", paymentId);
         return ResPaymentDto.from(payment);
     }
 }

--- a/src/main/java/com/example/delivery/payment/infrastructure/pg/PgClient.java
+++ b/src/main/java/com/example/delivery/payment/infrastructure/pg/PgClient.java
@@ -21,4 +21,13 @@ public interface PgClient {
      * @return 승인 응답 (성공/실패, 거래 ID, 실패 사유)
      */
     PgResponse requestApproval(UUID orderId, int amount);
+
+    /**
+     * PG사에 환불 요청.
+     *
+     * @param pgTransactionId 원거래 PG 거래 ID
+     * @param amount          환불 금액
+     * @return 환불 응답 (성공/실패, 실패 사유)
+     */
+    PgResponse requestRefund(String pgTransactionId, int amount);
 }

--- a/src/main/java/com/example/delivery/payment/infrastructure/pg/SimulatedPgClient.java
+++ b/src/main/java/com/example/delivery/payment/infrastructure/pg/SimulatedPgClient.java
@@ -38,4 +38,19 @@ public class SimulatedPgClient implements PgClient {
         log.warn("[SimulatedPG] 승인 실패 — orderId={}", orderId);
         return PgResponse.failure("시뮬레이션 결제 거절");
     }
+
+    @Override
+    public PgResponse requestRefund(String pgTransactionId, int amount) {
+        log.info("[SimulatedPG] 환불 요청 — pgTransactionId={}, amount={}", pgTransactionId, amount);
+
+        boolean success = ThreadLocalRandom.current().nextDouble() < SUCCESS_RATE;
+
+        if (success) {
+            log.info("[SimulatedPG] 환불 성공 — pgTransactionId={}", pgTransactionId);
+            return PgResponse.success(pgTransactionId);
+        }
+
+        log.warn("[SimulatedPG] 환불 실패 — pgTransactionId={}", pgTransactionId);
+        return PgResponse.failure("시뮬레이션 환불 거절");
+    }
 }

--- a/src/test/java/com/example/delivery/payment/application/service/PaymentServiceV1Test.java
+++ b/src/test/java/com/example/delivery/payment/application/service/PaymentServiceV1Test.java
@@ -214,22 +214,44 @@ class PaymentServiceV1Test {
     class CancelPayment {
 
         @Test
-        @DisplayName("COMPLETED 결제 취소 → CANCELLED 상태")
+        @DisplayName("PG 환불 성공 → CANCELLED 상태")
         void completedPayment_cancelSucceeds() {
             // given
             UUID paymentId = UUID.randomUUID();
             PaymentEntity payment = buildPayment(PaymentStatus.COMPLETED);
             given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+            given(pgClient.requestRefund(any(), anyInt()))
+                    .willReturn(PgResponse.success("SIM-refund-tx"));
 
             // when
             ResPaymentDto result = paymentService.cancelPayment(paymentId);
 
             // then
             assertThat(result.status()).isEqualTo(PaymentStatus.CANCELLED.name());
+            verify(pgClient).requestRefund(any(), anyInt());
         }
 
         @Test
-        @DisplayName("FAILED 결제 취소 시도 → INVALID_PAYMENT_STATUS 예외")
+        @DisplayName("PG 환불 실패 → REFUND_FAILED 예외, PG 호출 1회 확인")
+        void pgRefundFailed_throwsRefundFailed() {
+            // given
+            UUID paymentId = UUID.randomUUID();
+            PaymentEntity payment = buildPayment(PaymentStatus.COMPLETED);
+            given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+            given(pgClient.requestRefund(any(), anyInt()))
+                    .willReturn(PgResponse.failure("잔액 부족"));
+
+            // when / then
+            assertThatThrownBy(() -> paymentService.cancelPayment(paymentId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.REFUND_FAILED));
+
+            verify(pgClient).requestRefund(any(), anyInt());
+        }
+
+        @Test
+        @DisplayName("FAILED 결제 취소 시도 → INVALID_PAYMENT_STATUS 예외, PG 호출 없음")
         void failedPayment_cancelThrowsException() {
             // given
             UUID paymentId = UUID.randomUUID();
@@ -241,6 +263,8 @@ class PaymentServiceV1Test {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_PAYMENT_STATUS));
+
+            verify(pgClient, never()).requestRefund(any(), anyInt());
         }
     }
 }


### PR DESCRIPTION
결제 취소 시 PG 환불 호출 없이 DB 상태만 변경하던 버그를 수정한다.

- PgClient.requestRefund() 인터페이스 메서드 추가
- SimulatedPgClient.requestRefund() 구현 (성공률 90% 시뮬레이션)
- ErrorCode.REFUND_FAILED 추가 (HTTP 500)
- cancelPayment(): payment.cancel() 후 PG 환불 요청, 환불 실패 시 BusinessException(REFUND_FAILED)으로 트랜잭션 롤백
- PaymentServiceV1Test: PG 환불 성공/실패/상태불일치 케이스 추가