### PR TITLE
bug: validate payment amount against order total price

### DIFF
--- a/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/delivery/global/common/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     PAYMENT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다."),
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다."),
     INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "현재 결제 상태에서는 해당 작업을 수행할 수 없습니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 주문 금액과 일치하지 않습니다."),
     REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PG사 환불 요청이 실패했습니다. 잠시 후 다시 시도해 주세요."),
 
     // Review

--- a/src/main/java/com/example/delivery/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/example/delivery/payment/application/service/PaymentServiceV1.java
@@ -2,6 +2,7 @@ package com.example.delivery.payment.application.service;
 
 import com.example.delivery.global.common.exception.BusinessException;
 import com.example.delivery.global.common.exception.ErrorCode;
+import com.example.delivery.order.domain.entity.OrderEntity;
 import com.example.delivery.order.domain.repository.OrderRepository;
 import com.example.delivery.payment.domain.entity.PaymentEntity;
 import com.example.delivery.payment.domain.entity.PaymentStatus;
@@ -47,9 +48,13 @@ public class PaymentServiceV1 {
 
     @Transactional
     public ResPaymentDto processPayment(ReqCreatePaymentDto dto) {
-        // 1. 주문 존재 검증
-        orderRepository.findById(dto.orderId())
+        // 1. 주문 존재 검증 + 금액 일치 확인
+        OrderEntity order = orderRepository.findById(dto.orderId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        if (!dto.amount().equals(order.getTotalPrice())) {
+            throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
 
         // 2. 기존 결제 조회 — 상태별 분기
         //    FAILED: 기존 엔티티 재사용(retry) → orderId UNIQUE 제약 충돌 방지

--- a/src/test/java/com/example/delivery/payment/application/service/PaymentServiceV1Test.java
+++ b/src/test/java/com/example/delivery/payment/application/service/PaymentServiceV1Test.java
@@ -13,7 +13,6 @@ import com.example.delivery.global.common.exception.BusinessException;
 import com.example.delivery.global.common.exception.ErrorCode;
 import com.example.delivery.order.domain.entity.OrderEntity;
 import com.example.delivery.order.domain.repository.OrderRepository;
-import static org.mockito.Mockito.mock;
 import com.example.delivery.payment.domain.entity.PaymentEntity;
 import com.example.delivery.payment.domain.entity.PaymentStatus;
 import com.example.delivery.payment.domain.repository.PaymentRepository;
@@ -48,6 +47,14 @@ class PaymentServiceV1Test {
         return new ReqCreatePaymentDto(ORDER_ID, AMOUNT);
     }
 
+    private OrderEntity buildOrder(int totalPrice) {
+        return OrderEntity.builder()
+                .customerId("user01")
+                .storeId(UUID.randomUUID())
+                .totalPrice(totalPrice)
+                .build();
+    }
+
     private PaymentEntity buildPayment(PaymentStatus status) {
         PaymentEntity p = PaymentEntity.builder()
                 .orderId(ORDER_ID)
@@ -70,7 +77,7 @@ class PaymentServiceV1Test {
         @DisplayName("PG 승인 성공 → COMPLETED 상태로 저장")
         void success_completed() {
             // given
-            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(mock(OrderEntity.class)));
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(buildOrder(AMOUNT)));
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
             given(pgClient.requestApproval(eq(ORDER_ID), eq(AMOUNT)))
                     .willReturn(PgResponse.success("SIM-abc-123"));
@@ -90,7 +97,7 @@ class PaymentServiceV1Test {
         @DisplayName("PG 승인 실패 → FAILED 상태로 저장")
         void pgFailed_statusFailed() {
             // given
-            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(mock(OrderEntity.class)));
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(buildOrder(AMOUNT)));
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.empty());
             given(pgClient.requestApproval(eq(ORDER_ID), eq(AMOUNT)))
                     .willReturn(PgResponse.failure("잔액 부족"));
@@ -103,6 +110,24 @@ class PaymentServiceV1Test {
             assertThat(result.status()).isEqualTo(PaymentStatus.FAILED.name());
             assertThat(result.pgTransactionId()).isNull();
             assertThat(result.paidAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("결제 금액이 주문 금액과 불일치 → PAYMENT_AMOUNT_MISMATCH 예외, PG 호출 없음")
+        void amountMismatch_throwsException() {
+            // given — 주문 금액 25_000, 요청 금액 1_000 (과소 결제 시도)
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(buildOrder(AMOUNT)));
+
+            ReqCreatePaymentDto mismatchedRequest = new ReqCreatePaymentDto(ORDER_ID, 1_000);
+
+            // when / then
+            assertThatThrownBy(() -> paymentService.processPayment(mismatchedRequest))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.PAYMENT_AMOUNT_MISMATCH));
+
+            verify(pgClient, never()).requestApproval(any(), anyInt());
+            verify(paymentRepository, never()).save(any());
         }
 
         @Test
@@ -126,7 +151,7 @@ class PaymentServiceV1Test {
         void duplicateCompleted_throwsException() {
             // given
             PaymentEntity existing = buildPayment(PaymentStatus.COMPLETED);
-            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(mock(OrderEntity.class)));
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(buildOrder(AMOUNT)));
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(existing));
 
             // when / then
@@ -143,7 +168,7 @@ class PaymentServiceV1Test {
         void duplicateReady_throwsException() {
             // given
             PaymentEntity existing = buildPayment(PaymentStatus.READY);
-            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(mock(OrderEntity.class)));
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(buildOrder(AMOUNT)));
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(existing));
 
             // when / then
@@ -158,7 +183,7 @@ class PaymentServiceV1Test {
         void retryAfterFailed_succeeds() {
             // given: 이전 결제가 FAILED 상태
             PaymentEntity failedPayment = buildPayment(PaymentStatus.FAILED);
-            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(mock(OrderEntity.class)));
+            given(orderRepository.findById(ORDER_ID)).willReturn(Optional.of(buildOrder(AMOUNT)));
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(failedPayment));
             given(pgClient.requestApproval(eq(ORDER_ID), eq(AMOUNT)))
                     .willReturn(PgResponse.success("SIM-retry-tx"));


### PR DESCRIPTION
결제 요청 금액과 주문 금액 불일치 시 과소 결제가 가능하던 보안 취약점을 수정한다.

- ErrorCode.PAYMENT_AMOUNT_MISMATCH 추가 (HTTP 400)
- processPayment(): 주문 조회 후 dto.amount와 order.totalPrice 일치 여부 검증, 불일치 시 BusinessException(PAYMENT_AMOUNT_MISMATCH) — PG 호출 없이 즉시 거부
- PaymentServiceV1Test: buildOrder() 헬퍼 추가, mock(OrderEntity) → buildOrder(AMOUNT) 교체, 과소 결제 시도 케이스 추가