### PR TITLE
config: AWS EC2 배포 및 GitHub Actions CI/CD 파이프라인 설정 (#59)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,92 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ci:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - run: chmod +x gradlew
+
+      # build 태스크에 test가 포함되므로 별도 test 태스크 불필요
+      - run: ./gradlew --no-daemon clean build
+
+  cd:
+    name: Deploy to EC2
+    needs: ci
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/delivery-app:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/delivery-app:${{ github.sha }}
+
+      - uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd ~/app
+
+            # 배포 전 현재 이미지 저장 (롤백용)
+            PREV_IMAGE=$(docker inspect delivery-app \
+              --format='{{.Image}}' 2>/dev/null || echo "")
+            echo "$PREV_IMAGE" > ~/app/.prev_image
+
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/delivery-app:latest
+            docker compose up -d --no-deps app
+
+            # Health Check (최대 30초 대기)
+            for i in $(seq 1 6); do
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                http://localhost:8080/actuator/health)
+              if [ "$STATUS" = "200" ]; then
+                docker image prune -f
+                echo "Health check passed"
+                exit 0
+              fi
+              echo "Waiting... ($i/6)"
+              sleep 5
+            done
+
+            # Health Check 실패 시 자동 롤백
+            echo "Health check failed — rolling back"
+            PREV=$(cat ~/app/.prev_image)
+            if [ -n "$PREV" ]; then
+              docker tag "$PREV" \
+                ${{ secrets.DOCKERHUB_USERNAME }}/delivery-app:latest
+              docker compose up -d --no-deps app
+            fi
+            exit 1

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: delivery
       POSTGRES_PASSWORD: delivery
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -15,23 +15,23 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    restart: unless-stopped
 
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ${DOCKERHUB_USERNAME}/delivery-app:latest
     container_name: delivery-app
+    env_file:
+      - .env
+    environment:
+      JAVA_OPTS: "-Xms128m -Xmx256m"
+    mem_limit: 512m
+    memswap_limit: 512m
     depends_on:
       postgres:
         condition: service_healthy
-    environment:
-      DB_HOST: postgres
-      DB_PORT: "5432"
-      DB_NAME: delivery
-      DB_USERNAME: delivery
-      DB_PASSWORD: delivery
     ports:
       - "8080:8080"
+    restart: unless-stopped
 
 volumes:
   postgres_data:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 2
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+
+server:
+  tomcat:
+    threads:
+      max: 50
+      min-spare: 5
+
+logging:
+  level:
+    root: INFO
+    com.example.delivery: INFO
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,4 +28,4 @@ jwt:
 # 구글 Gemini API 설정
 gemini:
   api-url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
-  api-key: ${GEMINI_API_KEY}
+  api-key: ${GEMINI_API_KEY:test-api-key}


### PR DESCRIPTION
## 개요 
AWS EC2 배포 환경 구성 및 GitHub Actions 기반 CI/CD 파이프라인 설정 (#59)

## 변경 사항
- `.github/workflows/ci-cd.yml` — CI/CD 파이프라인 추가
 - PR 생성 시 CI 실행 (`./gradlew clean build`, 실패 시 머지 차단)
- main 머지 시 CD 실행 (Docker 이미지 빌드 → Docker Hub Push → EC2 배포)
- Health Check 실패 시 이전 이미지로 자동 롤백
- `docker-compose.yml` — 운영 환경 설정 반영
- app 서비스에 Docker Hub 이미지·환경변수·메모리 제한 적용 (`-Xmx256m`, `mem_limit: 512m`)
- PostgreSQL 포트 외부 노출 차단 (`127.0.0.1:5432:5432`)
- `application-prod.yml` — 운영 프로필 설정 추가
- PostgreSQL 연결, 환경변수 설정, HikariCP/Tomcat 스레드 수 제한
- `/actuator/health` 외부 노출 (Health Check용)
- `build.gradle` — Spring Actuator 의존성 추가

## 인프라 구성
- AWS EC2 t3.micro (Ubuntu 22.04) + Docker Compose
- 이미지 저장소: Docker Hub (`:latest` + `:{sha}` 태그)
- 환경 분리: `local·test → H2` / `prod → PostgreSQL`
- 스왑 2GB + JVM 힙 256MB 제한으로 t3.micro OOM 방지