### PR TITLE
Bug: AreaServiceV1Test 및 CategoryServiceV1Test 오류 해결 (#61)

### DIFF
--- a/src/test/java/com/example/delivery/area/application/service/AreaServiceV1Test.java
+++ b/src/test/java/com/example/delivery/area/application/service/AreaServiceV1Test.java
@@ -10,6 +10,7 @@ import com.example.delivery.area.presentation.dto.request.ReqUpdateAreaDto;
 import com.example.delivery.area.presentation.dto.response.ResCreateAreaDto;
 import com.example.delivery.area.presentation.dto.response.ResGetAreaDto;
 import com.example.delivery.global.common.response.PageResponse;
+import com.example.delivery.store.domain.repository.StoreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,9 @@ class AreaServiceV1Test {
 
     @Mock
     private AreaRepository areaRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
 
     @InjectMocks
     private AreaServiceV1 areaService;
@@ -380,6 +384,8 @@ class AreaServiceV1Test {
             assertThat(area.isDeleted()).isTrue();
             assertThat(getField(area, "deletedBy")).isEqualTo("master01");
             assertThat(getField(area, "deletedAt")).isNotNull();
+
+            verify(storeRepository).existsByAreaId(areaId);
         }
 
         @Test

--- a/src/test/java/com/example/delivery/category/application/service/CategoryServiceV1Test.java
+++ b/src/test/java/com/example/delivery/category/application/service/CategoryServiceV1Test.java
@@ -10,6 +10,7 @@ import com.example.delivery.category.presentation.dto.request.ReqUpdateCategoryD
 import com.example.delivery.category.presentation.dto.response.ResCreateCategoryDto;
 import com.example.delivery.category.presentation.dto.response.ResGetCategoryDto;
 import com.example.delivery.global.common.response.PageResponse;
+import com.example.delivery.store.domain.repository.StoreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,9 @@ class CategoryServiceV1Test {
 
     @Mock
     private CategoryRepository categoryRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
 
     @InjectMocks
     private CategoryServiceV1 categoryService;
@@ -330,6 +334,8 @@ class CategoryServiceV1Test {
             assertThat(category.isDeleted()).isTrue();
             assertThat(getField(category, "deletedBy")).isEqualTo("master01");
             assertThat(getField(category, "deletedAt")).isNotNull();
+
+            verify(storeRepository).existsByCategoryId(categoryId);
         }
 
         @Test


### PR DESCRIPTION
## 연관 이슈
Close #61 

## 해결 내용
지역 삭제 테스트 및 카테고리 삭제 테스트에서 `NullPointException`이 발생했던 오류 수정했습니다.
이전 PR에서 Area 및 Category 삭제 로직에 Store 관련 로직이 추가됨으로써 발생했던 오류였습니다.
`@Mock` 으로 `StoreRespository`를 주입 받아서 해결했습니다.