### PR TITLE
config: allow CD to run even if CI fails (#59)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,7 +34,7 @@ jobs:
   cd:
     name: Deploy to EC2
     needs: ci
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 개요   
  CI 실패 여부와 관계없이 CD가 실행되도록 조건 수정 (CI 확인 없이 배포 확인 목적)

## 변경 사항
  - `.github/workflows/ci-cd.yml` — CD job 실행 조건에 `always()` 추가

## 비고
- 테스트 실패 이슈 해결 후 `always()` 제거 예정