### PR TITLE
config: remove always() condition from CD job (#59)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,7 +34,7 @@ jobs:
   cd:
     name: Deploy to EC2
     needs: ci
-    if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 작업 내용
  - CD job의 always() 조건 제거
  - CI 실패 시 CD가 실행되지 않도록 수정
     (기존 always() -> 임시 배포하기 위해 테스트 코드 실패로 CI 통과 못해도 CD 실행될 수 있도록 설정)

  ## Test plan
  - main 머지 후 GitHub Actions CI → CD 순서로 실행되는지 확인
  - CI 통과 시 CD 정상 실행 확인
  - curl http://13.63.255.49:8080/actuator/health → {"status":"UP"} 응답 확인