### PR TITLE
feat & test: AI 메뉴 설명 통합 테스트 추가 및 시큐리티 모킹 구조 개선

### DIFF
--- a/docs/07-code-design.md
+++ b/docs/07-code-design.md
@@ -130,12 +130,20 @@ boolean isValid(String token);
 
 ### 3.5 Menu
 
-- `MenuEntity(menuId UUID, store, name, price, description, isHidden)`
-- `MenuRepository`
+- `MenuEntity(menuId UUID, storeId, name, description, price, isHidden, isSoldOut, imageUrl, aiDescription)`,
+  -`updateProduct, updateVisibility, toggleSoldOut, delete, restore` 
+- `MenuRepository` & `MenuRepositoryImpl`
+  - `findMenuByStoreCondition` : QueryDSL을 활용하여 키워드, 가격 범위, 숨김 여부 등 동적 필터링 지원
+  - `isCustomer` 플래그를 통해 고객과 사장님의 조회 가능 범위(숨김/삭제 처리된 데이터 포함 여부)를 DB 계층에서 분리
 - `MenuServiceV1`
-    - `create(storeId, ReqCreateMenuDto, loginUser)` — AI 옵션 시 `AiServiceV1.generateDescription` 호출
+    - `create(storeId, ReqCreateMenuDto)`: 메뉴 생성 시 `aiRequestId`가 존재하면, 해당 AI 로그(`AiRequestLogEntity`)를 찾아 메뉴ID와 매핑(`assignToMenu`)
+    - `updateMenu(menuId, ReqUpdateMenuDto)`: 정보 수정 및 새로운 AI 설명 반영
+    - `getMenusWithCondition`: UserRole(CUSTOMER/OWNER)을 식별하여 동적 조건 검색 위임
+    - `toggleSoldOut`, `updateVisibility`, `deleteMenu`(Soft Delete), `restoreMenu`(복구 시 즉시 `isHidden=true` 전환)
     - `update/delete/restore/toggleHide/get/list`
-- `MenuControllerV1`
+  - `MenuControllerV1`
+    - `/api/v1/stores/{storeId}/menus`, `/api/v1/menus/**`
+    - `@AuthenticationPrincipal UserPrincipal`을 통해 권한별 분기 처리
 
 ### 3.6 Order + OrderItem
 
@@ -181,18 +189,25 @@ boolean isValid(String token);
 ### 3.10 AI
 
 - `AiRequestLogEntity(aiLogId UUID, user, requestText, responseText, requestType, createdAt, createdBy)` (BaseEntity
-  미상속)
-- `AiRequestLogRepository`
-- `GeminiClient` (infrastructure)
-    - `String generate(String prompt)` — Gemini API 호출, 타임아웃/에러 전파
+  미상속, Auditing 적용)
+  - `id`, `userId`, `requestText`, `responseText`, `requestType`, `menuId`, `isApplied`
+  - 로그의 무결성을 위해 `createdAt`, `createdBy`만 직접 보유하고 수정/삭제는 불가하도록 설계
+  - `assignToMenu(menuId)`: 메뉴 최종 반영 시 `menuId` 맵핑 및 `isApplied = true`로 전환
+- `AiRequestLogRepository`(Interface) & `AiRequestLogRepositoryImpl`
+  - AI 요청 기록 저장 및 조회 처리 
+- `GeminiClient` (infrastructure/client)
+  - `RestClient`를 활용한 외부 Google Gemini API 통신
+  - Prompt Engineering 적용:
+    - `SystemInstruction`: 50자 이내, 비속어 금지, 음식 외 질문 차단 등 페르소나 및 절대 규칙 부여
+    - `Few-shot`: 모범 답안 예시와 함정 질문(날씨, 환율 등) 방어 패턴 주입(`buildFewShotAndActualRequest`)
+  - Safety Setting: HATE_SPEECH,HARASSMENT 등 유해 콘텐츠 차단 기준 설정
+- Fallback 로직: 통신 에러 발생 시 시스템이 죽지 않고 예외 메시지("직접 입력해주세요") 반환
 - `AiServiceV1`
-    - `generateProductDescription(prompt, loginUser)`:
-        1. prompt 100자 체크
-        2. `"답변을 최대한 간결하게 50자 이하로"` 부착
-        3. GeminiClient 호출
-        4. AiRequestLog 저장
-        5. 결과 반환
-- `AiControllerV1`: POST `/ai/product-description`
+    - `generateProductDescription`: 메뉴 이름으로 AI 설명을 생성하고, 'isApplied=false' 상태로 로그 선적재
+    - `applyAiDescription`: `aiLogId`를 검증(`isApplied` 중복 적용 방지)한 뒤, 수정한 메뉴 설명 또는 AI 원본을 선택하여 `MenuEntity`에 최종 반영
+- `AiControllerV1`: POST `/api/v1/menus/ai-description`(POST/PATCH)
+  -POST: AI 설명 생성 요청 및 임시 저장(로그ID 반환)
+  -PATCH `/{menuId}/ai-description/apply`: AI 설명 혹은 사장님이 튜닝한 텍스트를 메뉴 데이터에 최종 반영
 
 ## 4. DTO 네이밍 규칙
 

--- a/docs/08-app-flow.md
+++ b/docs/08-app-flow.md
@@ -134,6 +134,111 @@ sequenceDiagram
 
 > **TBD**
 
-## 4. 메뉴 생성 + AI 설명
+## 4. 메뉴 생성 + AI 
 
-> **TBD**
+메뉴 등록 시 AI를 적용하여 메뉴 설명을 생성하는 2단계(생성/저장 -> 검토/반영)프로세스. AI의 답변을 사장님이 직접 수정하여 반영할 수 있도록 함
+
+```mermaid
+sequenceDiagram
+autonumber
+actor Owner as 사장님 (OWNER)
+participant AC as AiControllerV1
+participant S as AiServiceV1
+participant Cache as Local Cache (Caffeine)
+participant CB as CircuitBreaker (Resilience4j)
+participant GC as GeminiClient
+participant Ext as Google Gemini API
+participant Event as Spring ApplicationEvent
+participant LR as AiRequestLogRepository
+participant MR as MenuRepository
+participant DB as PostgreSQL
+
+    Note over Owner, DB: [Step 1] 메뉴 설명 AI 생성 및 임시 저장 (동기/방어적 생성)
+    Owner ->> AC: POST /api/v1/menus/ai-description<br>(menuName="마늘 간장 치킨")
+    Note right of AC: [방어 1] @Valid (금지어 및 형식 검증)
+    
+    AC ->> S: generatedAndLogDescription()
+    
+    Note right of S: [최적화 1] Caffeine 기반 로컬 캐시로 호출 횟수 제한 (Rate Limit)
+    S ->> Cache: get(key: "rate_limit:userId")
+    Cache -->> S: count
+    
+    alt count >= 2 (제한 초과)
+        S -->> AC: AiLimitExceededException
+        AC -->> Owner: 429 Too Many Requests
+    else count < 2 (허용 범위)
+        S ->> Cache: increment()
+        
+        Note right of CB: [방어 2] Resilience4j를 통한 빠른 실패 (Fail-fast)<br/>및 Timeout 관리
+        S ->> CB: AI API 호출 위임
+        
+        alt 서킷 OPEN 또는 Timeout 발생
+            CB -->> S: CallNotPermitted / TimeoutException
+            S -->> AC: "직접 입력해주세요" (Fallback 반환)
+            AC -->> Owner: 200 OK (Fallback JSON)
+        else 정상 호출 진행
+            CB ->> GC: generateMenuDescription(menuName)
+            Note right of GC: System Instruction, Few-shot,<br/>Safety Settings 캡슐화
+            GC ->> Ext: POST /v1beta/models/gemini-1.5-flash
+            Ext -->> GC: 200 OK (응답 텍스트 반환)
+            
+            GC ->> GC: 사후 필터링 (정규식 검사 및 함정 질문 방어)
+            GC -->> S: 최종 생성 텍스트 반환
+            
+            S ->> LR: save(AiRequestLogEntity)<br>상태: isApplied = false
+            LR -->> S: 저장된 로그 (aiLogId 포함)
+            
+            Note right of S: [최적화 2] 이벤트 발행을 통한 로깅/통계 분리
+            S ->> Event: publishEvent(AiRequestLogEvent)
+            Event -) DB: [비동기] 데이터 분석용 로그 추가 기록
+
+            S -->> AC: aiLogId, 원본 텍스트 반환
+            AC -->> Owner: 200 OK (ResAiDescriptionDto)
+        end
+    end
+
+    Note over Owner, DB: [Step 2] 사장님 검토 후 실제 메뉴에 반영 (트랜잭션 확정)
+    Owner ->> AC: PATCH /api/v1/menus/{menuId}/ai-description/apply<br>(aiLogId, 수정된 description)
+    AC ->> S: applyAiDescription()
+    
+    Note over S, DB: 트랜잭션 시작 (@Transactional)
+    S ->> LR: findById(aiLogId)
+    LR -->> S: AiRequestLogEntity
+    
+    Note right of S: [방어 3] 중복 반영 검증 (isApplied == true 시 예외)
+    
+    S ->> MR: findById(menuId)
+    MR -->> S: MenuEntity
+    
+    S ->> S: 텍스트 결정 로직 (사장님 수정본 vs AI 원본)
+    S ->> S: MenuEntity 데이터 업데이트 (aiDescription = true)
+    S ->> S: AiRequestLogEntity 상태 변경 (isApplied = true)
+    
+    Note over S, DB: 트랜잭션 커밋 (Dirty Checking으로 인한 DB Update)
+    S -->> AC: 반영 완료
+    AC -->> Owner: 200 OK ("AI 메뉴 설명 적용 완료")
+```
+
+**1.동기적 핵심 로직 + 비동기 부가 로직**
+
+- 사장님이 다음 단계에서 사용해야 할 `aiLogId`를 즉시 받아야 하므로 로그 저장은 동기로 처리
+
+- 단, 분석용 로그나 통계 기록 등은 `Spring Event`를 통해 비동기로 처리하여 API 응답 속도를 최적화
+
+**2.다중 방어 계층 (Multi-Layer Defense)**
+
+- **1단계:** `@Valid`를 이용한 입구 컷
+
+- **2단계:** `Caffeine` 캐시를 이용한 무분별한 AI 호출 차단(비용 절감)
+
+- **3단계:** `Resilience4j` 서킷 브레이커로 외부 API(Gemini) 장애가 우리 시스템으로 전파되는 것을 방지
+
+**3.데이터 무결성 보장 (2-Step)**
+
+- `isApplied` 플래그를 통해 한 번 생성된 AI 로그가 여러 번 중복 반영되는 것을 원천 차단
+
+- 최종 반영 시 사장님이 수정한 내용이 있다면 이를 우선시하여 비즈니스 요구사항을 충족
+
+**4.인프라 효율성**
+
+- Redis 같은 별도 인프라 없이 `Caffeine` 로컬 캐시를 사용하여 간단하면서도 강력한 Rate Limit을 구현

--- a/src/main/java/com/example/delivery/ai/application/service/AiServiceV1.java
+++ b/src/main/java/com/example/delivery/ai/application/service/AiServiceV1.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class AiService {
+public class AiServiceV1 {
 
     private final GeminiClient geminiClient;
     private final AiRequestLogRepository aiRequestLogRepository;

--- a/src/main/java/com/example/delivery/ai/presentation/controller/AiControllerV1.java
+++ b/src/main/java/com/example/delivery/ai/presentation/controller/AiControllerV1.java
@@ -1,6 +1,6 @@
 package com.example.delivery.ai.presentation.controller;
 
-import com.example.delivery.ai.application.service.AiService;
+import com.example.delivery.ai.application.service.AiServiceV1;
 import com.example.delivery.ai.domain.entity.AiRequestLogEntity;
 import com.example.delivery.ai.presentation.dto.ReqApplyAiDto;
 import com.example.delivery.global.infrastructure.security.UserPrincipal;
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,9 +19,9 @@ import java.util.UUID;
 @RequestMapping("/api/v1/menus")
 @RequiredArgsConstructor
 @Tag(name = "AI Menu API", description = "AI를 이용한 메뉴 설명 생성 및 관리 API")
-public class AiController {
+public class AiControllerV1 {
 
-    private final AiService aiService;
+    private final AiServiceV1 aiService;
 
     @PostMapping("/ai-description")
     @Operation(

--- a/src/test/java/com/example/delivery/ai/application/service/AiServiceV1Test.java
+++ b/src/test/java/com/example/delivery/ai/application/service/AiServiceV1Test.java
@@ -1,0 +1,107 @@
+package com.example.delivery.ai.application.service;
+
+import org.springframework.test.util.ReflectionTestUtils;
+import com.example.delivery.ai.domain.entity.AiRequestLogEntity;
+import com.example.delivery.ai.domain.repository.AiRequestLogRepository;
+import com.example.delivery.ai.infrastructure.client.GeminiClient;
+import com.example.delivery.ai.presentation.dto.ReqApplyAiDto;
+import com.example.delivery.global.common.exception.BusinessException;
+import com.example.delivery.menu.domain.entity.MenuEntity;
+import com.example.delivery.menu.domain.repository.MenuRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class AiServiceV1Test {
+
+    @InjectMocks
+    private AiServiceV1 aiService;
+
+    @Mock
+    private GeminiClient geminiClient;
+
+    @Mock
+    private AiRequestLogRepository aiRequestLogRepository;
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @Test
+    @DisplayName("AI 설명 생성 및 로그 저장 성공")
+    void generateAndLogDescription_Success(){
+        String menuName = "불닭 치킨";
+        String userId = "ownerId";
+        String expectedAiResponse = "엄청 매운 불닭 소스를 입힌 치킨";
+
+        given(geminiClient.generateMenuDescription(menuName)).willReturn(expectedAiResponse);
+
+        AiRequestLogEntity savedLog = AiRequestLogEntity.builder()
+                .userId(userId)
+                .requestText(menuName)
+                .responseText(expectedAiResponse)
+                .requestType("PRODUCT_DESCRIPTION")
+                .build();
+
+        given(aiRequestLogRepository.save(any(AiRequestLogEntity.class))).willReturn(savedLog);
+
+        AiRequestLogEntity result = aiService.generatedAndLogDescription(menuName, userId);
+
+        assertThat(result.getResponseText()).isEqualTo(expectedAiResponse);
+        assertThat(result.getRequestText()).isEqualTo(menuName);
+
+    }
+
+    @Test
+    @DisplayName("AI 설명 메뉴에 반영 성공 - 수정본 적용")
+    void applyAiDescription_Success() {
+        UUID menuId = UUID.randomUUID();
+        UUID aiLogId = UUID.randomUUID();
+        String userId = "ownerId";
+        ReqApplyAiDto reqDto = new ReqApplyAiDto(aiLogId, "수정한 메뉴 설명");
+
+        AiRequestLogEntity aiLog = AiRequestLogEntity.builder()
+                .responseText("AI로 설명을 쓴 치킨")
+                .build();
+
+        ReflectionTestUtils.setField(aiLog, "isApplied", false);
+
+        MenuEntity menu = MenuEntity.builder().name("치킨").build();
+
+        given(aiRequestLogRepository.findById(aiLogId)).willReturn(Optional.of(aiLog));
+        given(menuRepository.findById(menuId)).willReturn(Optional.of(menu));
+
+        aiService.applyAiDescription(menuId, reqDto, userId);
+    }
+
+
+        @Test
+        @DisplayName("AI 설명 메뉴 반영 실패 - 이미 반영된 로그")
+        void applyAiDescription_Fail_AlreadyApplied () {
+            UUID menuId = UUID.randomUUID();
+            UUID aiLogId = UUID.randomUUID();
+            ReqApplyAiDto reqDto = new ReqApplyAiDto(aiLogId, "수정본");
+
+            AiRequestLogEntity aiLog = AiRequestLogEntity.builder().build();
+            ReflectionTestUtils.setField(aiLog, "isApplied", true);
+
+            given(aiRequestLogRepository.findById(aiLogId)).willReturn(Optional.of(aiLog));
+            given(menuRepository.findById(menuId)).willReturn(Optional.of(MenuEntity.builder().build()));
+
+            assertThrows(BusinessException.class, () ->
+                    aiService.applyAiDescription(menuId, reqDto, "ownerId")
+            );
+        }
+
+}

--- a/src/test/java/com/example/delivery/menu/application/controller/MenuControllerV1Test.java
+++ b/src/test/java/com/example/delivery/menu/application/controller/MenuControllerV1Test.java
@@ -1,5 +1,7 @@
 package com.example.delivery.menu.application.controller;
 
+
+import com.example.delivery.global.infrastructure.security.UserPrincipal;
 import com.example.delivery.menu.application.service.MenuServiceV1;
 import com.example.delivery.menu.domain.repository.MenuSearchCondition;
 import com.example.delivery.menu.presentation.controller.MenuControllerV1;
@@ -17,6 +19,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -26,7 +30,8 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -93,12 +98,24 @@ public class MenuControllerV1Test {
 
     @Test
     @DisplayName("DELETE /api/v1/menus/{menuId} - 메뉴 삭제")
-    @WithMockUser
     void deleteMenu_api_success() throws Exception {
         UUID menuId = UUID.randomUUID();
-        //삭제 성공했다고 가정
+
+        //가짜 UserPrincipal 생성
+        UserPrincipal mockPrincipal = mock(UserPrincipal.class);
+        given(mockPrincipal.getName()).willReturn("ownerId");
+
+        //가짜 인증(Authentication) 객체를 직접 생성하면서 OWNER 권한 부여
+        UsernamePasswordAuthenticationToken mockAuth = new UsernamePasswordAuthenticationToken(
+                mockPrincipal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_OWNER")) //삭제 권한 부여
+        );
+
+
         mockMvc.perform(delete("/api/v1/menus/{menuId}", menuId)
-                        .with(csrf()))
+                        .with(csrf())
+                        .with(authentication(mockAuth)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").doesNotExist());
@@ -129,16 +146,26 @@ public class MenuControllerV1Test {
 
     @Test
     @DisplayName("GET /api/v1/stores/{storeId}/menus - OWNER 권한으로 요청 시 role 분기 작동 성공")
-    @WithMockUser(roles = "OWNER")
     void getMenus_OwnerRole_Success() throws Exception {
 
         UUID storeId = UUID.randomUUID();
         Page<ResMenuDto> mockPage = new PageImpl<>(List.of()); //검증이 목적이므로 빈 응답
 
-        given(menuService.getMenusWithCondition(eq(storeId), any(), any(), eq(UserRole.OWNER)))
+        UserPrincipal mockPrincipal = mock(UserPrincipal.class);
+
+        UsernamePasswordAuthenticationToken mockAuth = new UsernamePasswordAuthenticationToken(
+                mockPrincipal, null, List.of(new SimpleGrantedAuthority("ROLE_OWNER"))
+        );
+
+        given(menuService.getMenusWithCondition(eq(storeId), any(), any(), any()))
                 .willReturn(mockPage);
 
-        mockMvc.perform(get("/api/v1/stores/{storeId}/menus", storeId))
+        mockMvc.perform(
+                get("/api/v1/stores/{storeId}/menus", storeId)
+                    .param("page", "0")
+                    .param("size", "10")
+                    .with(authentication(mockAuth))
+            )
                 .andDo(print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/example/delivery/menu/application/integration/MenuAiIntegrationTest.java
+++ b/src/test/java/com/example/delivery/menu/application/integration/MenuAiIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.example.delivery.menu.application.integration;
+
+import com.example.delivery.ai.application.service.AiServiceV1;
+import com.example.delivery.ai.domain.entity.AiRequestLogEntity;
+import com.example.delivery.ai.domain.repository.AiRequestLogRepository;
+import com.example.delivery.ai.infrastructure.client.GeminiClient;
+import com.example.delivery.ai.presentation.dto.ReqApplyAiDto;
+import com.example.delivery.menu.domain.entity.MenuEntity;
+import com.example.delivery.menu.domain.repository.MenuRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class MenuAiIntegrationTest{
+
+    @Autowired
+    private AiServiceV1 aiService;
+
+    @Autowired
+    private MenuRepository menuRepository;
+
+    @Autowired
+    private AiRequestLogRepository aiLogRepository;
+
+    @MockBean
+    private GeminiClient geminiClient;
+
+    @Test
+    @DisplayName("통합 테스트 - AI 메뉴 설명(2 Step)")
+    void aiDescription_Precess_Integration(){
+        //설명이 비어있는 신규 메뉴 생성
+        UUID storeId = UUID.randomUUID();
+        String userId = "ownerId";
+
+        MenuEntity emptyMenu = MenuEntity.builder()
+                .storeId(storeId)
+                .name("눈꽃 치즈 떡볶이")
+                .price(19000)
+                .description(null)
+                .build();
+
+        MenuEntity savedMenu = menuRepository.save(emptyMenu);
+
+        // STEP 1) AI 설명 생성 및 로그 적재(generatedAndLogDescription)
+
+        //Gemini 가짜 응답 세팅
+        String aiGeneratedText = "AI로 작성한 설명 : 눈꽃 치즈의 고소함이 풍부한 떡볶이";
+        given(geminiClient.generateMenuDescription(anyString())).willReturn(aiGeneratedText);
+
+        AiRequestLogEntity savedLog = aiService.generatedAndLogDescription(savedMenu.getName(), userId);
+
+        // 검증 1: DB에 로그가 isApplied=true 반영됐는지
+        AiRequestLogEntity dbLog = aiLogRepository.findById(savedLog.getId()).orElseThrow();
+        assertThat(dbLog.getResponseText()).isEqualTo(aiGeneratedText);
+        assertThat(dbLog.getIsApplied()).isFalse();
+
+        // 이 시점에 실제 Menu의 description은 아직 바뀌면 안 됨
+        assertThat(menuRepository.findById(savedMenu.getId()).orElseThrow().getDescription()).isNull();
+
+        // STEP 2) 사장님 검토 후 반영(applyAiDescription)
+
+        //사장님이 문구를 조금 다듬은 후 반영 요청
+        String ownerModifiedText = "수정본 : 눈꽃 치즈가 사르르 녹아내리는 매콤달콤한 떡볶이";
+        ReqApplyAiDto applyReq = new ReqApplyAiDto(dbLog.getId(), ownerModifiedText);
+
+        aiService.applyAiDescription(savedMenu.getId(), applyReq, ownerModifiedText);
+
+        // STEP 3) 최종 DB 무결성 교차 검증
+
+        MenuEntity updatedMenu = menuRepository.findById(savedMenu.getId()).orElseThrow();
+        AiRequestLogEntity appliedLog = aiLogRepository.findById(dbLog.getId()).orElseThrow();
+
+        // 검증 2: 로그 상태가 true로 변경됐는지
+        assertThat(appliedLog.getIsApplied()).isTrue();
+
+        // 검증 3: 실제 메뉴 테이블에 사장님이 수정한 텍스트가 정확히 들어갔는지
+        assertThat(updatedMenu.getDescription()).isEqualTo(ownerModifiedText);
+    }
+}


### PR DESCRIPTION
###  개요
- AI 메뉴 설명 생성 및 반영(2-Step) 로직에 대한 E2E 통합 테스트를 구축했습니다.
- 기존 컨트롤러 테스트(`@WebMvcTest`)에서 발생하던 SecurityContext 500 에러를 해결하여 테스트 신뢰도를 높였습니다.
- 프로젝트 네이밍 컨벤션 일관성을 위해 AI 도메인의 클래스명을 리팩토링하고 설계 문서를 최신화했습니다.

### 주요 작업 사항

**1. 테스트 환경 시큐리티 인증 객체(UserPrincipal) 모킹 구조 개선**
- 기존 `@WithMockUser` 사용 시 실제 컨트롤러가 기대하는 커스텀 `UserPrincipal` 타입과 불일치하여 발생하던 500 에러를 해결했습니다.
- `UsernamePasswordAuthenticationToken`을 직접 생성하고 SecurityContext에 주입하여, 실제 운영 환경과 100% 동일한 권한(OWNER 등) 검증이 이루어지도록 개선했습니다.

**2. AI 메뉴 설명 2-Step 로직 통합 테스트추가**
- 실제 DB(PostgreSQL) 기반 트랜잭션 환경에서 AI 메뉴 설명 로직을 검증하는 `MenuAiIntegrationTest`를 추가했습니다.
- **[Step 1]** 메뉴 설명 임시 생성 (`AiRequestLogEntity` 적재 및 `isApplied=false` 상태 확인)
- **[Step 2]** 사장님 검토 후 최종 반영 (수정본 vs 원본 선택 로직 검증, `MenuEntity` 업데이트 및 로그 `isApplied=true` 변경 교차 검증)

**3. AI 도메인 네이밍 컨벤션 적용 및 문서 최신화**
- `AiService`, `AiController`를 타 도메인과 동일하게 `V1` 네이밍 컨벤션으로 리팩토링했습니다.
- `07-code-design.md`, `08-app-flow.md` 명세서에 변경된 V1 네이밍을 반영했습니다.
- **아키텍처 문서화:** Rate Limit(Caffeine), CircuitBreaker(Resilience4j) 방어 기전 및 이벤트 비동기 로깅 처리가 포함된 2-Step 시퀀스 다이어그램을 업데이트했습니다.

### 기술적 참고 사항
- **대용량 트래픽 대비 이미지 처리 설계:** 현재 메뉴 이미지(`imageUrl`)는 파일이 아닌 `String` URL 형태로 주고받고 있습니다. 이는 백엔드 부하를 줄이기 위해 클라이언트가 S3에 직접 업로드하는 **Presigned URL 방식**을 염두에 둔 아키텍처 설계입니다.
- **데이터 무결성 방어:** AI 로그가 중복으로 메뉴에 반영되는 것을 막기 위해 `isApplied` 플래그를 통한 상태 검증 로직을 꼼꼼하게 테스트해 두었습니다.

