### PR TITLE
Feature: Area 비활성 시 가게 숨김 (#68)

### DIFF
--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustomImpl.java
@@ -33,8 +33,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     public Page<StoreEntity> search(String keyword, UUID categoryId, UUID areaId, Pageable pageable) {
 
         BooleanExpression[] conditions = new BooleanExpression[]{
-                notDeleted(),
-                notHidden(),
+                storeNotDeleted(),
+                storeNotHidden(),
                 areaIsActive(),
                 nameContainsIgnoreCase(keyword),
                 categoryIdEq(categoryId),
@@ -65,11 +65,11 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     /**
      * 조건 조립 (null 이면 조건 자체를 제외)
      */
-    private BooleanExpression notDeleted() {
+    private BooleanExpression storeNotDeleted() {
         return STORE.deletedAt.isNull();
     }
 
-    private BooleanExpression notHidden() {
+    private BooleanExpression storeNotHidden() {
         return STORE.isHidden.isFalse();
     }
 

--- a/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/example/delivery/store/infrastructure/repository/StoreRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.example.delivery.store.infrastructure.repository;
 
+import com.example.delivery.area.domain.entity.QAreaEntity;
 import com.example.delivery.store.domain.entity.QStoreEntity;
 import com.example.delivery.store.domain.entity.StoreEntity;
 import com.querydsl.core.types.Order;
@@ -24,6 +25,7 @@ import java.util.UUID;
 public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
 
     private static final QStoreEntity STORE = QStoreEntity.storeEntity;
+    private static final QAreaEntity AREA = QAreaEntity.areaEntity;
 
     private final JPAQueryFactory queryFactory;
 
@@ -33,6 +35,7 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
         BooleanExpression[] conditions = new BooleanExpression[]{
                 notDeleted(),
                 notHidden(),
+                areaIsActive(),
                 nameContainsIgnoreCase(keyword),
                 categoryIdEq(categoryId),
                 areaIdEq(areaId)
@@ -40,6 +43,7 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
 
         List<StoreEntity> content = queryFactory
                 .selectFrom(STORE)
+                .join(AREA).on(STORE.areaId.eq(AREA.id))
                 .where(conditions)
                 .orderBy(toOrderSpecifiers(pageable.getSort()))
                 .offset(pageable.getOffset())
@@ -49,6 +53,7 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
         Long totalCount = queryFactory
                 .select(STORE.count())
                 .from(STORE)
+                .join(AREA).on(STORE.areaId.eq(AREA.id))
                 .where(conditions)
                 .fetchOne();
 
@@ -66,6 +71,10 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
 
     private BooleanExpression notHidden() {
         return STORE.isHidden.isFalse();
+    }
+
+    private BooleanExpression areaIsActive() {
+        return AREA.isActive.isTrue();
     }
 
     private BooleanExpression nameContainsIgnoreCase(String keyword) {


### PR DESCRIPTION
## 관련 이슈
Closes #68 

## 변경 사항
`StoreRepositoryCustomImpl.search()` 에 Area 활성 상태 필터를 추가하여,
비활성 지역(`is_active=false`) 또는 soft-delete 된 지역에 속한 가게는 검색 결과에서 제외되도록 수정습니다.

## 구현 상세
- `p_store` ↔ `p_area` INNER JOIN 추가 (`store.area_id = area.area_id`)
  - `StoreEntity.areaId` 가 단순 UUID 컬럼(연관관계 매핑 X) 이므로 명시적 `join...on` 사용
  - `area_id` 가 NOT NULL 컬럼이라 INNER JOIN 안전
- `areaIsActive()` (기존에 정의되어 있지만 미사용 상태였음) 를 conditions 배열에 포함
- `areaNotDeleted()` 메서드 신규 추가
- **content 쿼리와 count 쿼리에 동일한 join/조건 적용** → `totalCount` 어긋남 방지

## 설계 노트
Area 비활성화 시 Store의 `is_hidden` 을 cascade update 하는 방식 대신,
조회 시점에 파생 필터링하는 방식을 선택했습니다.

| 항목 | Cascade update | Join 필터 (선택) |
|---|---|---|
| Area 재활성화 시 복구 | 사장 수동 숨김 가게와 구분 불가, 데이터 손실 | 자연스럽게 복구됨 |
| 도메인 결합도 | Store ↔ Area 상태 결합 | 도메인 분리 유지 |
| 트랜잭션 범위 | Area update 시 Store까지 일괄 변경 필요 | 변경 없음 |
| 추가 비용 | Store 일괄 update 비용 | 매 조회 시 join 1회 |

`area_id` 에는 인덱스(`idx_store_area`)가 이미 걸려 있어 join 비용은 무시 가능 수준입니다.