### PR TITLE
test: 리뷰 도메인 통합 테스트 (#69)

### DIFF
--- a/docs/03-data-spec.md
+++ b/docs/03-data-spec.md
@@ -223,7 +223,8 @@ erDiagram
 | review_id   | UUID        | PK                             |         |
 | order_id    | UUID        | FK → p_order, UNIQUE, NOT NULL | 1주문 1리뷰 |
 | store_id    | UUID        | FK → p_store, NOT NULL         | 역정규화    |
-| customer_id | VARCHAR(10) | FK → p_user.username, NOT NULL |         |
+| customer_id       | VARCHAR(10) | FK → p_user.username, NOT NULL |       |
+| customer_nickname | VARCHAR(50) | NOT NULL                       | 작성 시점 닉네임 |
 | rating      | INTEGER     | NOT NULL, CHECK 1~5            |         |
 | content     | TEXT        |                                |         |
 | + Audit 6개  |             |                                |         |

--- a/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
@@ -88,5 +88,61 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
             assertThat(storeRepository.findById(store.getId()).orElseThrow().getAverageRating())
                     .isEqualByComparingTo("5.0");
         }
+
+        @Test
+        @DisplayName("주문이 COMPLETED 아닌 상태 → 400")
+        void fail_orderNotCompleted() throws Exception {
+            // given — PENDING 상태 주문 (Order 기본값)
+            OrderEntity order = orderRepository.save(OrderEntity.builder()
+                    .customerId(CUSTOMER_USERNAME)
+                    .storeId(store.getId())
+                    .totalPrice(15000)
+                    .build());
+            ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!");
+
+            // when / then
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("동일 주문에 중복 리뷰 생성 → 409")
+        void fail_duplicateReview() throws Exception {
+            // given — 이미 리뷰가 존재하는 주문
+            OrderEntity order = seedCompletedOrder(CUSTOMER_USERNAME);
+            ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!");
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isCreated());
+
+            // when — 같은 주문에 리뷰 재시도
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isConflict());
+        }
+
+        @Test
+        @DisplayName("본인 주문 아닌 경우 → 403")
+        void fail_notMyOrder() throws Exception {
+            // given — 다른 유저 주문
+            seedUser("other01", UserRole.CUSTOMER);
+            OrderEntity order = seedCompletedOrder("other01");
+            ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!");
+
+            // when / then
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isForbidden());
+        }
     }
 }

--- a/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
@@ -3,8 +3,10 @@ package com.example.delivery.review.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.delivery.global.test.IntegrationTestSupport;
@@ -331,6 +333,69 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
             mockMvc.perform(delete("/api/v1/reviews/{reviewId}", reviewId)
                             .header("Authorization", "Bearer " + ownerToken))
                     .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 조회")
+    class GetReview {
+
+        @Test
+        @DisplayName("가게 리뷰 목록 조회 (필터 없음) → 전체 리뷰 반환")
+        void getReviewsByStore_noFilter() throws Exception {
+            // given — 평점이 다른 리뷰 2개 생성
+            seedUser("other01", UserRole.CUSTOMER);
+            String otherToken = login("other01", DEFAULT_PASSWORD);
+
+            OrderEntity order1 = seedCompletedOrder(CUSTOMER_USERNAME);
+            OrderEntity order2 = seedCompletedOrder("other01");
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order1.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqCreateReviewDto(5, "맛있었어요!"))))
+                    .andExpect(status().isCreated());
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order2.getOrderId())
+                            .header("Authorization", "Bearer " + otherToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqCreateReviewDto(3, "보통이었어요"))))
+                    .andExpect(status().isCreated());
+
+            // when / then
+            mockMvc.perform(get("/api/v1/stores/{storeId}/reviews", store.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalElements").value(2));
+        }
+
+        @Test
+        @DisplayName("가게 리뷰 목록 조회 (평점 5점 필터) → 해당 평점 리뷰만 반환")
+        void getReviewsByStore_ratingFilter() throws Exception {
+            // given — 평점 5점, 3점 리뷰 각 1개 생성
+            seedUser("other01", UserRole.CUSTOMER);
+            String otherToken = login("other01", DEFAULT_PASSWORD);
+
+            OrderEntity order1 = seedCompletedOrder(CUSTOMER_USERNAME);
+            OrderEntity order2 = seedCompletedOrder("other01");
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order1.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqCreateReviewDto(5, "맛있었어요!"))))
+                    .andExpect(status().isCreated());
+
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order2.getOrderId())
+                            .header("Authorization", "Bearer " + otherToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqCreateReviewDto(3, "보통이었어요"))))
+                    .andExpect(status().isCreated());
+
+            // when / then — 5점 필터 시 1개만 반환
+            mockMvc.perform(get("/api/v1/stores/{storeId}/reviews", store.getId())
+                            .param("rating", "5"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.content[0].rating").value(5));
         }
     }
 }

--- a/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
@@ -302,5 +302,35 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
 
             assertThat(reviewRepository.findById(reviewId)).isEmpty();
         }
+
+        @Test
+        @DisplayName("타인 리뷰 삭제 시도 (CUSTOMER) → 403")
+        void fail_notMyReview() throws Exception {
+            // given — other01 이 작성한 리뷰
+            seedUser("other01", UserRole.CUSTOMER);
+            OrderEntity order = seedCompletedOrder("other01");
+            String otherToken = login("other01", DEFAULT_PASSWORD);
+            UUID reviewId = createReview(otherToken, order.getOrderId());
+
+            // when — customer01 이 타인 리뷰 삭제 시도
+            mockMvc.perform(delete("/api/v1/reviews/{reviewId}", reviewId)
+                            .header("Authorization", "Bearer " + customerToken))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("OWNER 권한으로 리뷰 삭제 시도 → 403")
+        void fail_ownerForbidden() throws Exception {
+            // given
+            seedUser("owner01", UserRole.OWNER);
+            String ownerToken = login("owner01", DEFAULT_PASSWORD);
+            OrderEntity order = seedCompletedOrder(CUSTOMER_USERNAME);
+            UUID reviewId = createReview(customerToken, order.getOrderId());
+
+            // when / then
+            mockMvc.perform(delete("/api/v1/reviews/{reviewId}", reviewId)
+                            .header("Authorization", "Bearer " + ownerToken))
+                    .andExpect(status().isForbidden());
+        }
     }
 }

--- a/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.example.delivery.review.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.order.domain.entity.OrderEntity;
+import com.example.delivery.order.domain.entity.OrderStatus;
+import com.example.delivery.order.domain.repository.OrderRepository;
+import com.example.delivery.review.domain.repository.ReviewRepository;
+import com.example.delivery.review.presentation.dto.request.ReqCreateReviewDto;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import com.example.delivery.user.domain.entity.UserRole;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ReviewIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired OrderRepository orderRepository;
+    @Autowired StoreRepository storeRepository;
+    @Autowired ReviewRepository reviewRepository;
+
+    private StoreEntity store;
+    private String customerToken;
+    private static final String CUSTOMER_USERNAME = "customer01";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        seedUser(CUSTOMER_USERNAME, UserRole.CUSTOMER);
+        store = storeRepository.save(StoreEntity.builder()
+                .ownerId(UUID.randomUUID())
+                .categoryId(UUID.randomUUID())
+                .areaId(UUID.randomUUID())
+                .name("테스트 가게")
+                .address("서울시 강남구")
+                .phone("010-0000-0000")
+                .minOrderAmount(10000)
+                .build());
+        customerToken = login(CUSTOMER_USERNAME, DEFAULT_PASSWORD);
+    }
+
+    private OrderEntity seedCompletedOrder(String customerId) {
+        OrderEntity order = orderRepository.save(OrderEntity.builder()
+                .customerId(customerId)
+                .storeId(store.getId())
+                .totalPrice(15000)
+                .build());
+        ReflectionTestUtils.setField(order, "status", OrderStatus.COMPLETED);
+        return orderRepository.save(order);
+    }
+
+    @Nested
+    @DisplayName("리뷰 생성")
+    class CreateReview {
+
+        @Test
+        @DisplayName("주문 완료 상태 + 본인 주문 → review DB 저장, store averageRating 반영")
+        void success_dbVerified() throws Exception {
+            // given
+            OrderEntity order = seedCompletedOrder(CUSTOMER_USERNAME);
+            ReqCreateReviewDto req = new ReqCreateReviewDto(5, "맛있었어요!");
+
+            // when
+            mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isCreated());
+
+            // then — DB 교차 검증
+            assertThat(reviewRepository.existsByOrderId(order.getOrderId())).isTrue();
+            assertThat(storeRepository.findById(store.getId()).orElseThrow().getAverageRating())
+                    .isEqualByComparingTo("5.0");
+        }
+    }
+}

--- a/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
@@ -2,6 +2,7 @@ package com.example.delivery.review.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -11,6 +12,7 @@ import com.example.delivery.order.domain.entity.OrderStatus;
 import com.example.delivery.order.domain.repository.OrderRepository;
 import com.example.delivery.review.domain.repository.ReviewRepository;
 import com.example.delivery.review.presentation.dto.request.ReqCreateReviewDto;
+import com.example.delivery.review.presentation.dto.request.ReqUpdateReviewDto;
 import com.example.delivery.store.domain.entity.StoreEntity;
 import com.example.delivery.store.domain.repository.StoreRepository;
 import com.example.delivery.user.domain.entity.UserRole;
@@ -143,6 +145,43 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(req)))
                     .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 수정")
+    class UpdateReview {
+
+        @Test
+        @DisplayName("본인 리뷰 수정 → DB 반영, store averageRating 재계산 확인")
+        void success_dbVerified() throws Exception {
+            // given — 리뷰 생성 후 수정
+            OrderEntity order = seedCompletedOrder(CUSTOMER_USERNAME);
+            ReqCreateReviewDto createReq = new ReqCreateReviewDto(5, "맛있었어요!");
+
+            String createBody = mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order.getOrderId())
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(createReq)))
+                    .andExpect(status().isCreated())
+                    .andReturn().getResponse().getContentAsString();
+
+            UUID reviewId = UUID.fromString(
+                    objectMapper.readTree(createBody).path("data").path("reviewId").asText());
+
+            ReqUpdateReviewDto updateReq = new ReqUpdateReviewDto(3, "다시 생각해보니 보통이었어요");
+
+            // when
+            mockMvc.perform(patch("/api/v1/reviews/{reviewId}", reviewId)
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateReq)))
+                    .andExpect(status().isOk());
+
+            // then — DB 교차 검증
+            assertThat(reviewRepository.findById(reviewId).orElseThrow().getRating()).isEqualTo(3);
+            assertThat(storeRepository.findById(store.getId()).orElseThrow().getAverageRating())
+                    .isEqualByComparingTo("3.0");
         }
     }
 }

--- a/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
@@ -183,5 +183,63 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
             assertThat(storeRepository.findById(store.getId()).orElseThrow().getAverageRating())
                     .isEqualByComparingTo("3.0");
         }
+
+        @Test
+        @DisplayName("타인 리뷰 수정 시도 (CUSTOMER) → 403")
+        void fail_notMyReview() throws Exception {
+            // given — other01 이 작성한 리뷰
+            seedUser("other01", UserRole.CUSTOMER);
+            OrderEntity order = seedCompletedOrder("other01");
+            String otherToken = login("other01", DEFAULT_PASSWORD);
+
+            String createBody = mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", order.getOrderId())
+                            .header("Authorization", "Bearer " + otherToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqCreateReviewDto(5, "맛있었어요!"))))
+                    .andExpect(status().isCreated())
+                    .andReturn().getResponse().getContentAsString();
+
+            UUID reviewId = UUID.fromString(
+                    objectMapper.readTree(createBody).path("data").path("reviewId").asText());
+
+            // when — customer01 이 타인 리뷰 수정 시도
+            mockMvc.perform(patch("/api/v1/reviews/{reviewId}", reviewId)
+                            .header("Authorization", "Bearer " + customerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqUpdateReviewDto(1, "별로였어요"))))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("OWNER 권한으로 리뷰 수정 시도 → 403")
+        void fail_ownerForbidden() throws Exception {
+            // given
+            seedUser("owner01", UserRole.OWNER);
+            String ownerToken = login("owner01", DEFAULT_PASSWORD);
+            UUID randomReviewId = UUID.randomUUID();
+
+            // when / then
+            mockMvc.perform(patch("/api/v1/reviews/{reviewId}", randomReviewId)
+                            .header("Authorization", "Bearer " + ownerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqUpdateReviewDto(1, "수정"))))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("MANAGER 권한으로 리뷰 수정 시도 → 403")
+        void fail_managerForbidden() throws Exception {
+            // given
+            seedUser("manager01", UserRole.MANAGER);
+            String managerToken = login("manager01", DEFAULT_PASSWORD);
+            UUID randomReviewId = UUID.randomUUID();
+
+            // when / then
+            mockMvc.perform(patch("/api/v1/reviews/{reviewId}", randomReviewId)
+                            .header("Authorization", "Bearer " + managerToken)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqUpdateReviewDto(1, "수정"))))
+                    .andExpect(status().isForbidden());
+        }
     }
 }

--- a/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
+++ b/src/test/java/com/example/delivery/review/integration/ReviewIntegrationTest.java
@@ -2,6 +2,7 @@ package com.example.delivery.review.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,6 +17,7 @@ import com.example.delivery.review.presentation.dto.request.ReqUpdateReviewDto;
 import com.example.delivery.store.domain.entity.StoreEntity;
 import com.example.delivery.store.domain.repository.StoreRepository;
 import com.example.delivery.user.domain.entity.UserRole;
+import jakarta.persistence.EntityManager;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +39,7 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
     @Autowired OrderRepository orderRepository;
     @Autowired StoreRepository storeRepository;
     @Autowired ReviewRepository reviewRepository;
+    @Autowired EntityManager entityManager;
 
     private StoreEntity store;
     private String customerToken;
@@ -240,6 +243,64 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(new ReqUpdateReviewDto(1, "수정"))))
                     .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 삭제")
+    class DeleteReview {
+
+        private UUID createReview(String token, UUID orderId) throws Exception {
+            String body = mockMvc.perform(post("/api/v1/orders/{orderId}/reviews", orderId)
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(new ReqCreateReviewDto(5, "맛있었어요!"))))
+                    .andExpect(status().isCreated())
+                    .andReturn().getResponse().getContentAsString();
+            return UUID.fromString(objectMapper.readTree(body).path("data").path("reviewId").asText());
+        }
+
+        @Test
+        @DisplayName("본인 리뷰 삭제 → soft delete 반영, store averageRating 0.0 재계산")
+        void success_customer_dbVerified() throws Exception {
+            // given
+            OrderEntity order = seedCompletedOrder(CUSTOMER_USERNAME);
+            UUID reviewId = createReview(customerToken, order.getOrderId());
+
+            // when
+            mockMvc.perform(delete("/api/v1/reviews/{reviewId}", reviewId)
+                            .header("Authorization", "Bearer " + customerToken))
+                    .andExpect(status().isNoContent());
+
+            // then — 1차 캐시 비우고 DB 조회
+            entityManager.flush();
+            entityManager.clear();
+
+            assertThat(reviewRepository.findById(reviewId)).isEmpty();  // soft delete → SQLRestriction 으로 조회 불가
+            assertThat(storeRepository.findById(store.getId()).orElseThrow().getAverageRating())
+                    .isEqualByComparingTo("0.0");
+        }
+
+        @Test
+        @DisplayName("MASTER 권한으로 타인 리뷰 삭제 → soft delete 반영")
+        void success_master_dbVerified() throws Exception {
+            // given
+            OrderEntity order = seedCompletedOrder(CUSTOMER_USERNAME);
+            UUID reviewId = createReview(customerToken, order.getOrderId());
+
+            seedUser("master01", UserRole.MASTER);
+            String masterToken = login("master01", DEFAULT_PASSWORD);
+
+            // when
+            mockMvc.perform(delete("/api/v1/reviews/{reviewId}", reviewId)
+                            .header("Authorization", "Bearer " + masterToken))
+                    .andExpect(status().isNoContent());
+
+            // then — 1차 캐시 비우고 DB 조회
+            entityManager.flush();
+            entityManager.clear();
+
+            assertThat(reviewRepository.findById(reviewId)).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## 개요
- 리뷰 도메인 통합 테스트 작성
- 기존 Mock 기반 단위 테스트가 검증하지 못하는 DB 흐름 검증
- review 테이블 저장 후, 평점 재계산 DB 검증

## 구현 내용
- 리뷰 생성
  - 성공 : review DB 저장, 평점 재계산 반영
  - 실패 : COMPLETED 아닌 주문(400), 중복 리뷰(409), 타인 주문(403)
- 리뷰 수정
  - 성공 : DB 반영, 평점 재계산 반영
  - 실패 : 타인 리뷰(403), OWNER/MANAGER 권한(403)
- 리뷰 삭제
  - 성공 : soft delete 반영, 평점 재계산 반영
  - 실패 : 타인 리뷰(403), OWNER 권한(403)
 - 리뷰 목록 조회 : 전체 목록 반환, 평점 필터 반환
 - docs 누락 필드 보완