### PR TITLE
Test: Area, Category, Store 통합테스트 (#71)

### DIFF
--- a/src/main/java/com/example/delivery/area/presentation/controller/AreaControllerV1.java
+++ b/src/main/java/com/example/delivery/area/presentation/controller/AreaControllerV1.java
@@ -14,12 +14,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Slf4j
 @Tag(name = "Area", description = "지역 API")
 @RestController
 @RequestMapping("/api/v1/areas")
@@ -38,6 +41,7 @@ public class AreaControllerV1 {
     })
     @PostMapping
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ResCreateAreaDto> createArea(@Valid @RequestBody ReqCreateAreaDto request) {
         return ApiResponse.created(areaService.createArea(request));
     }

--- a/src/main/java/com/example/delivery/category/presentation/controller/CategoryControllerV1.java
+++ b/src/main/java/com/example/delivery/category/presentation/controller/CategoryControllerV1.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +39,7 @@ public class CategoryControllerV1 {
     })
     @PostMapping
     @PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ResCreateCategoryDto> createCategory(@Valid @RequestBody ReqCreateCategoryDto request) {
         return ApiResponse.created(categoryService.createCategory(request));
     }

--- a/src/main/java/com/example/delivery/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/example/delivery/store/presentation/controller/StoreControllerV1.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -42,6 +43,7 @@ public class StoreControllerV1 {
     })
     @PostMapping
     @PreAuthorize("hasRole('OWNER')")
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<ResCreateStoreDto> createStore(
             @Valid @RequestBody ReqCreateStoreDto request,
             @AuthenticationPrincipal UserPrincipal userPrincipal

--- a/src/test/java/com/example/delivery/area/integration/AreaCrudIntegrationTest.java
+++ b/src/test/java/com/example/delivery/area/integration/AreaCrudIntegrationTest.java
@@ -1,0 +1,343 @@
+package com.example.delivery.area.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.area.presentation.dto.request.ReqCreateAreaDto;
+import com.example.delivery.area.presentation.dto.request.ReqUpdateAreaDto;
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.user.domain.entity.UserRole;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Area CRUD 통합 테스트 — 권한 매트릭스 + Validation + DB 영속 + 예외 핸들러까지의 흐름 검증.
+ *
+ * 정책 메모
+ * - SecurityConfig 에서 /api/v1/areas/** 는 anyRequest().permitAll() 에 해당하지만,
+ *   변경 계열 엔드포인트는 컨트롤러의 @PreAuthorize 로 권한이 강제된다.
+ *   따라서 미인증 POST/PATCH 의 응답은 ExceptionTranslationFilter 가 아니라
+ *   GlobalExceptionHandler.handleAccessDenied 를 통한 403 으로 정규화된다.
+ *   (UserAuthSmokeIntegrationTest 의 401 흐름과 다른 점에 주의)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AreaCrudIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    AreaRepository areaRepository;
+
+    // ────────────────────────────────────────────────
+    // POST /api/v1/areas
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("MANAGER 가 지역 생성 → 201 + DB 반영 + createdBy 설정")
+    void create_byManager_201() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateAreaDto body = new ReqCreateAreaDto("광화문", "서울특별시", "종로구", true);
+
+        authedPost("/api/v1/areas", token, body)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.name").value("광화문"))
+                .andExpect(jsonPath("$.data.city").value("서울특별시"))
+                .andExpect(jsonPath("$.data.district").value("종로구"))
+                .andExpect(jsonPath("$.data.isActive").value(true))
+                .andExpect(jsonPath("$.data.createdBy").value("manager01"));
+
+        Optional<AreaEntity> persisted = areaRepository.findByName("광화문");
+        assertThat(persisted).isPresent();
+        assertThat(persisted.get().getCreatedBy()).isEqualTo("manager01");
+    }
+
+    @Test
+    @DisplayName("MASTER 도 지역 생성 가능 → 201")
+    void create_byMaster_201() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        ReqCreateAreaDto body = new ReqCreateAreaDto("강남역", "서울특별시", "강남구", true);
+
+        authedPost("/api/v1/areas", token, body)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.createdBy").value("master01"));
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 지역 생성 시도 → 403 FORBIDDEN")
+    void create_byCustomer_403() throws Exception {
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        ReqCreateAreaDto body = new ReqCreateAreaDto("강남역", "서울특별시", "강남구", true);
+
+        authedPost("/api/v1/areas", token, body)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("OWNER 도 지역 생성 권한 없음 → 403")
+    void create_byOwner_403() throws Exception {
+        seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateAreaDto body = new ReqCreateAreaDto("강남역", "서울특별시", "강남구", true);
+
+        authedPost("/api/v1/areas", token, body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 상태에서 지역 생성 시도 → 403 (anonymous 에 대한 @PreAuthorize 거부)")
+    void create_unauthenticated_403() throws Exception {
+        ReqCreateAreaDto body = new ReqCreateAreaDto("강남역", "서울특별시", "강남구", true);
+
+        unauthedPost("/api/v1/areas", body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 지역명으로 생성 → 409 AREA_ALREADY_EXISTS")
+    void create_duplicateName_409() throws Exception {
+        seedArea("강남역", "서울특별시", "강남구", true);
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateAreaDto body = new ReqCreateAreaDto("강남역", "서울특별시", "강남구", true);
+
+        authedPost("/api/v1/areas", token, body)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 존재하는 지역명입니다."));
+    }
+
+    @Test
+    @DisplayName("이미 soft-delete 된 이름으로 재생성 → 400 AREA_ALREADY_DELETED")
+    void create_softDeletedName_400() throws Exception {
+        AreaEntity tobe = seedArea("강남역", "서울특별시", "강남구", true);
+        tobe.softDelete("master01");
+        areaRepository.save(tobe);
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateAreaDto body = new ReqCreateAreaDto("강남역", "서울특별시", "강남구", true);
+
+        authedPost("/api/v1/areas", token, body)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("삭제된 지역명입니다."));
+    }
+
+    @Test
+    @DisplayName("필수 필드 누락(name 빈 값) → 400 VALIDATION_ERROR + errors[name]")
+    void create_blankName_400() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateAreaDto body = new ReqCreateAreaDto("   ", "서울특별시", "강남구", true);
+
+        authedPost("/api/v1/areas", token, body)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.errors[?(@.field=='name')]").exists());
+    }
+
+    @Test
+    @DisplayName("필수 필드 누락(isActive null) → 400 VALIDATION_ERROR")
+    void create_nullIsActive_400() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        // record 직렬화 우회를 위해 raw JSON 사용
+        String raw = """
+                {"name":"강남역","city":"서울특별시","district":"강남구"}
+                """;
+
+        mockMvc.perform(post("/api/v1/areas")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(APPLICATION_JSON)
+                        .content(raw))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.errors[?(@.field=='isActive')]").exists());
+    }
+
+    // ────────────────────────────────────────────────
+    // GET /api/v1/areas, GET /api/v1/areas/{id}
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("미인증 상태에서도 지역 단건 조회 가능(권한 없음) → 200")
+    void getOne_unauthenticated_200() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        mockMvc.perform(get("/api/v1/areas/{id}", area.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("광화문"))
+                .andExpect(jsonPath("$.data.areaId").value(area.getId().toString()));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 areaId 단건 조회 → 404 AREA_NOT_FOUND")
+    void getOne_notFound_404() throws Exception {
+        mockMvc.perform(get("/api/v1/areas/{id}", UUID.randomUUID()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("지역을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("키워드 부분일치 + 페이지네이션 → 매칭 항목만 반환")
+    void getAll_keywordFilter_paginated() throws Exception {
+        seedArea("광화문", "서울특별시", "종로구", true);
+        seedArea("광교", "경기도", "수원시", true);
+        seedArea("강남역", "서울특별시", "강남구", true);
+
+        mockMvc.perform(get("/api/v1/areas")
+                        .param("keyword", "광")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.content[?(@.name=='광화문')]").exists())
+                .andExpect(jsonPath("$.data.content[?(@.name=='광교')]").exists());
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 page size(7) → 10 으로 보정")
+    void getAll_invalidSize_normalizedToTen() throws Exception {
+        seedArea("광화문", "서울특별시", "종로구", true);
+
+        mockMvc.perform(get("/api/v1/areas")
+                        .param("page", "0")
+                        .param("size", "7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.size").value(10));
+    }
+
+    // ────────────────────────────────────────────────
+    // PATCH /api/v1/areas/{id}
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("MANAGER 가 지역 수정 → 200 + DB 반영")
+    void update_byManager_200() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateAreaDto body = new ReqUpdateAreaDto("광화문(개편)", "서울특별시", "종로구", false);
+
+        authedPatch("/api/v1/areas/" + area.getId(), token, body)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("광화문(개편)"))
+                .andExpect(jsonPath("$.data.isActive").value(false));
+
+        AreaEntity reloaded = areaRepository.findById(area.getId()).orElseThrow();
+        assertThat(reloaded.getName()).isEqualTo("광화문(개편)");
+        assertThat(reloaded.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 지역 수정 시도 → 403")
+    void update_byCustomer_403() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        ReqUpdateAreaDto body = new ReqUpdateAreaDto("광화문2", "서울특별시", "종로구", true);
+
+        authedPatch("/api/v1/areas/" + area.getId(), token, body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("다른 살아있는 지역과 동일한 이름으로 수정 → 409")
+    void update_duplicateName_409() throws Exception {
+        AreaEntity target = seedArea("광화문", "서울특별시", "종로구", true);
+        seedArea("강남역", "서울특별시", "강남구", true);
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateAreaDto body = new ReqUpdateAreaDto("강남역", "서울특별시", "종로구", true);
+
+        authedPatch("/api/v1/areas/" + target.getId(), token, body)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 존재하는 지역명입니다."));
+    }
+
+    @Test
+    @DisplayName("같은 이름으로 수정(자기 자신) → 중복 검증 통과 200")
+    void update_sameName_200() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateAreaDto body = new ReqUpdateAreaDto("광화문", "서울특별시", "종로구", false);
+
+        authedPatch("/api/v1/areas/" + area.getId(), token, body)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isActive").value(false));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 areaId 수정 → 404")
+    void update_notFound_404() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateAreaDto body = new ReqUpdateAreaDto("강남역", "서울특별시", "강남구", true);
+
+        authedPatch("/api/v1/areas/" + UUID.randomUUID(), token, body)
+                .andExpect(status().isNotFound());
+    }
+
+    // ────────────────────────────────────────────────
+    // private helpers (베이스 미수정 정책에 따라 클래스 로컬)
+    // ────────────────────────────────────────────────
+
+    private ResultActions authedPost(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private ResultActions unauthedPost(String url, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private AreaEntity seedArea(String name, String city, String district, boolean isActive) {
+        return areaRepository.save(AreaEntity.builder()
+                .name(name)
+                .city(city)
+                .district(district)
+                .isActive(isActive)
+                .build());
+    }
+}

--- a/src/test/java/com/example/delivery/area/integration/AreaDeleteGuardIntegrationTest.java
+++ b/src/test/java/com/example/delivery/area/integration/AreaDeleteGuardIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.example.delivery.area.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import com.example.delivery.store.presentation.dto.request.ReqCreateStoreDto;
+import com.example.delivery.user.domain.entity.UserEntity;
+import com.example.delivery.user.domain.entity.UserRole;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Area DELETE 정책 통합 테스트.
+ *
+ * 검증 포인트
+ * 1) DELETE /api/v1/areas/{id} 의 권한 매트릭스: MASTER 만 200, 그 외(MANAGER/OWNER/CUSTOMER/미인증) 403
+ * 2) 사용 중 Store 가 있으면 → 409 AREA_IN_USE
+ * 3) 성공 시 deletedAt/deletedBy 가 채워지고, 후속 단건 조회는 404
+ * 4) Soft-deleted areaId 로 Store 생성 시도 → 404 (RelatedAreaNotFoundException, AreaRepository.findByIdAndDeletedAtIsNull)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AreaDeleteGuardIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    AreaRepository areaRepository;
+    @Autowired
+    StoreRepository storeRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    // ────────────────────────────────────────────────
+    // 권한 매트릭스
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("MASTER 가 지역 삭제 → 200 + soft delete 반영(deletedAt/deletedBy)")
+    void delete_byMaster_softDeletes() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/areas/" + area.getId(), token)
+                .andExpect(status().isOk());
+
+        // Repository.findById 는 살아있는 row 만 보므로 직접 단건 조회로는 보이지 않음
+        assertThat(areaRepository.findById(area.getId())).isEmpty();
+        assertThat(areaRepository.findByNameIncludingDeleted("광화문")).isPresent();
+    }
+
+    @Test
+    @DisplayName("MANAGER 가 삭제 시도 → 403 (DELETE 는 MASTER 전용)")
+    void delete_byManager_403() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/areas/" + area.getId(), token)
+                .andExpect(status().isForbidden());
+
+        // 트랜잭션 내 실제로 삭제되지 않았는지 확인
+        assertThat(areaRepository.findById(area.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 삭제 시도 → 403")
+    void delete_byCustomer_403() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/areas/" + area.getId(), token)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 상태 DELETE 요청 → 403 (anonymous 에 대한 @PreAuthorize 거부)")
+    void delete_unauthenticated_403() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        mockMvc.perform(delete("/api/v1/areas/" + area.getId()))
+                .andExpect(status().isForbidden());
+
+        assertThat(areaRepository.findById(area.getId())).isPresent();
+    }
+
+    // ────────────────────────────────────────────────
+    // 사용 중 Store 가드
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("사용 중인 Store 가 있으면 → 409 AREA_IN_USE")
+    void delete_areaInUse_409() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+        seedStoreOn(area.getId());
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/areas/" + area.getId(), token)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("해당 지역을 사용 중인 가게가 있어 삭제할 수 없습니다."));
+
+        // 가드에 의해 실제로 삭제되지 않았어야 함
+        assertThat(areaRepository.findById(area.getId())).isPresent();
+    }
+
+    // ────────────────────────────────────────────────
+    // 삭제 후 후속 조회 / 재참조
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("삭제 성공 후 단건 조회 → 404")
+    void getAfterDelete_404() throws Exception {
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/areas/" + area.getId(), token)
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/areas/{id}", area.getId()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("지역을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("Soft-deleted areaId 로 Store 생성 시도 → 404 AREA_NOT_FOUND")
+    void createStoreWithDeletedArea_404() throws Exception {
+        // given: 카테고리(살아있음) + 지역(soft-deleted) + OWNER 로그인
+        CategoryEntity category = seedCategory("한식-IT");
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+        area.softDelete("master01");
+        areaRepository.save(area);
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        String token = login(owner.getUsername().value(), DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 분식", "서울 종로구 어딘가 1", null, 5000);
+
+        // when & then
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("지역을 찾을 수 없습니다."));
+    }
+
+    // ────────────────────────────────────────────────
+    // private helpers
+    // ────────────────────────────────────────────────
+
+    private ResultActions authedPost(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private AreaEntity seedArea(String name, String city, String district, boolean isActive) {
+        return areaRepository.save(AreaEntity.builder()
+                .name(name)
+                .city(city)
+                .district(district)
+                .isActive(isActive)
+                .build());
+    }
+
+    private CategoryEntity seedCategory(String name) {
+        return categoryRepository.save(CategoryEntity.builder().name(name).build());
+    }
+
+    /**
+     * area 사용 중 가드 검증 전용 — Store 도메인의 입력 검증/권한 흐름은 별도 테스트에서 다루므로,
+     * 여기서는 repository 직접 저장으로 store row 만 만든다.
+     * (StoreEntity 는 ownerId/categoryId 에 FK 제약이 없는 단순 UUID 컬럼이므로 임의 값 허용)
+     */
+    private StoreEntity seedStoreOn(UUID areaId) {
+        return storeRepository.save(StoreEntity.builder()
+                .ownerId(UUID.randomUUID())
+                .categoryId(UUID.randomUUID())
+                .areaId(areaId)
+                .name("사용중-가게")
+                .address("서울특별시 종로구 어딘가 1")
+                .phone(null)
+                .minOrderAmount(5000)
+                .build());
+    }
+}

--- a/src/test/java/com/example/delivery/category/integration/CategoryCrudIntegrationTest.java
+++ b/src/test/java/com/example/delivery/category/integration/CategoryCrudIntegrationTest.java
@@ -1,0 +1,317 @@
+package com.example.delivery.category.integration;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.presentation.dto.request.ReqCreateAreaDto;
+import com.example.delivery.area.presentation.dto.request.ReqUpdateAreaDto;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.category.presentation.dto.request.ReqCreateCategoryDto;
+import com.example.delivery.category.presentation.dto.request.ReqUpdateCategoryDto;
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Category CRUD 통합 테스트 — 권한 매트릭스 + Validation + DB 영속 + 예외 핸들러까지의 흐름 검증.
+ *
+ * 정책 메모
+ * - SecurityConfig 에서 /api/v1/categories/** 는 anyRequest().permitAll() 에 해당하지만,
+ *   변경 계열 엔드포인트는 컨트롤러의 @PreAuthorize 로 권한이 강제된다.
+ *   따라서 미인증 POST/PATCH 의 응답은 ExceptionTranslationFilter 가 아니라
+ *   GlobalExceptionHandler.handleAccessDenied 를 통한 403 으로 정규화된다.
+ *   (UserAuthSmokeIntegrationTest 의 401 흐름과 다른 점에 주의)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class CategoryCrudIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    // ────────────────────────────────────────────────
+    // POST /api/v1/categories
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("MANAGER 가 카테고리 생성 → 201 + DB 반영 + createdBy 설정")
+    void create_byManager_201() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto("한식");
+
+        authedPost("/api/v1/categories", token, body)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.name").value("한식"))
+                .andExpect(jsonPath("$.data.createdBy").value("manager01"));
+
+        Optional<CategoryEntity> persisted = categoryRepository.findByName("한식");
+        assertThat(persisted).isPresent();
+        assertThat(persisted.get().getCreatedBy()).isEqualTo("manager01");
+    }
+
+    @Test
+    @DisplayName("MASTER 도 카테고리 생성 가능 → 201")
+    void create_byMaster_201() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto("한식");
+
+        authedPost("/api/v1/categories", token, body)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.createdBy").value("master01"));
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 카테고리 생성 시도 → 403 FORBIDDEN")
+    void create_byCustomer_403() throws Exception {
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto("한식");
+
+        authedPost("/api/v1/categories", token, body)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("OWNER 도 카테고리 생성 권한 없음 → 403")
+    void create_byOwner_403() throws Exception {
+        seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto("한식");
+
+        authedPost("/api/v1/categories", token, body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 상태에서 카테고리 생성 시도 → 403 (anonymous 에 대한 @PreAuthorize 거부)")
+    void create_unauthenticated_403() throws Exception {
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto("한식");
+
+        unauthedPost("/api/v1/categories", body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 카테고리명으로 생성 → 409 CATEGORY_ALREADY_EXISTS")
+    void create_duplicateName_409() throws Exception {
+        seedCategory("한식");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto("한식");
+
+        authedPost("/api/v1/categories", token, body)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 존재하는 카테고리 이름입니다."));
+    }
+
+    @Test
+    @DisplayName("이미 soft-delete 된 이름으로 재생성 → 400 CATEGORY_ALREADY_DELETED")
+    void create_softDeletedName_400() throws Exception {
+        CategoryEntity tobe = seedCategory("한식");
+        tobe.softDelete("master01");
+        categoryRepository.save(tobe);
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto("한식");
+
+        authedPost("/api/v1/categories", token, body)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("삭제된 카테고리 이름입니다."));
+    }
+
+    @Test
+    @DisplayName("필수 필드 누락(name 빈 값) → 400 VALIDATION_ERROR + errors[name]")
+    void create_blankName_400() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqCreateCategoryDto body = new ReqCreateCategoryDto(" ");
+
+        authedPost("/api/v1/categories", token, body)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.errors[?(@.field=='name')]").exists());
+    }
+
+    // ────────────────────────────────────────────────
+    // GET /api/v1/categories, GET /api/v1/categories/{id}
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("미인증 상태에서도 카테고리 단건 조회 가능(권한 없음) → 200")
+    void getOne_unauthenticated_200() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        mockMvc.perform(get("/api/v1/categories/{id}", category.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("한식"))
+                .andExpect(jsonPath("$.data.categoryId").value(category.getId().toString()));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 categoryId 단건 조회 → 404 CATEGORY_NOT_FOUND")
+    void getOne_notFound_404() throws Exception {
+        mockMvc.perform(get("/api/v1/categories/{id}", UUID.randomUUID()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("카테고리를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("키워드 부분일치 + 페이지네이션 → 매칭 항목만 반환")
+    void getAll_keywordFilter_paginated() throws Exception {
+        seedCategory("한식");
+        seedCategory("중식");
+        seedCategory("치킨");
+
+        mockMvc.perform(get("/api/v1/categories")
+                        .param("keyword", "식")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.content[?(@.name=='한식')]").exists())
+                .andExpect(jsonPath("$.data.content[?(@.name=='중식')]").exists());
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 page size(7) → 10 으로 보정")
+    void getAll_invalidSize_normalizedToTen() throws Exception {
+        seedCategory("한식");
+
+        mockMvc.perform(get("/api/v1/categories")
+                        .param("page", "0")
+                        .param("size", "7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.size").value(10));
+    }
+
+    // ────────────────────────────────────────────────
+    // PATCH /api/v1/categories/{id}
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("MANAGER 가 카테고리 수정 → 200 + DB 반영")
+    void update_byManager_200() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateCategoryDto body = new ReqUpdateCategoryDto("한식(퓨전)");
+
+        authedPatch("/api/v1/categories/" + category.getId(), token, body)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("한식(퓨전)"));
+
+        CategoryEntity reloaded = categoryRepository.findById(category.getId()).orElseThrow();
+        assertThat(reloaded.getName()).isEqualTo("한식(퓨전)");
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 카테고리 수정 시도 → 403")
+    void update_byCustomer_403() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        ReqUpdateCategoryDto body = new ReqUpdateCategoryDto("한식(퓨전)");
+
+        authedPatch("/api/v1/categories/" + category.getId(), token, body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("다른 살아있는 카테고리와 동일한 이름으로 수정 → 409")
+    void update_duplicateName_409() throws Exception {
+        CategoryEntity target = seedCategory("한식(퓨전)");
+        seedCategory("한식");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateCategoryDto body = new ReqUpdateCategoryDto("한식");
+
+        authedPatch("/api/v1/categories/" + target.getId(), token, body)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 존재하는 카테고리 이름입니다."));
+    }
+
+    @Test
+    @DisplayName("같은 이름으로 수정(자기 자신) → 중복 검증 통과 200")
+    void update_sameName_200() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateCategoryDto body = new ReqUpdateCategoryDto("한식");
+
+        authedPatch("/api/v1/categories/" + category.getId(), token, body)
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 categoryId 수정 → 404")
+    void update_notFound_404() throws Exception {
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateCategoryDto body = new ReqUpdateCategoryDto("한식");
+
+        authedPatch("/api/v1/categories/" + UUID.randomUUID(), token, body)
+                .andExpect(status().isNotFound());
+    }
+
+    // ────────────────────────────────────────────────
+    // private helpers (베이스 미수정 정책에 따라 클래스 로컬)
+    // ────────────────────────────────────────────────
+
+    private ResultActions authedPost(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private ResultActions unauthedPost(String url, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private CategoryEntity seedCategory(String name) {
+        return categoryRepository.save(CategoryEntity.builder()
+                .name(name)
+                .build());
+    }
+}

--- a/src/test/java/com/example/delivery/category/integration/CategoryDeleteGuardIntegrationTest.java
+++ b/src/test/java/com/example/delivery/category/integration/CategoryDeleteGuardIntegrationTest.java
@@ -1,0 +1,215 @@
+package com.example.delivery.category.integration;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import com.example.delivery.store.presentation.dto.request.ReqCreateStoreDto;
+import com.example.delivery.user.domain.entity.UserEntity;
+import com.example.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Category DELETE 정책 통합 테스트.
+ *
+ * 검증 포인트
+ * 1) DELETE /api/v1/categories/{id} 의 권한 매트릭스: MASTER 만 200, 그 외(MANAGER/OWNER/CUSTOMER/미인증) 403
+ * 2) 사용 중 Store 가 있으면 → 409 CATEGORY_IN_USE
+ * 3) 성공 시 deletedAt/deletedBy 가 채워지고, 후속 단건 조회는 404
+ * 4) Soft-deleted categoryId 로 Store 생성 시도 → 404 (RelatedCategoryNotFoundException, CategoryRepository.findByIdAndDeletedAtIsNull)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class CategoryDeleteGuardIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    AreaRepository areaRepository;
+    @Autowired
+    StoreRepository storeRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    // ────────────────────────────────────────────────
+    // 권한 매트릭스
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("MASTER 가 카테고리 삭제 → 200 + soft delete 반영(deletedAt/deletedBy)")
+    void delete_byMaster_softDeletes() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/categories/" + category.getId(), token)
+                .andExpect(status().isOk());
+
+        // Repository.findById 는 살아있는 row 만 보므로 직접 단건 조회로는 보이지 않음
+        assertThat(categoryRepository.findById(category.getId())).isEmpty();
+        assertThat(categoryRepository.findByNameIncludingDeleted("한식")).isPresent();
+    }
+
+    @Test
+    @DisplayName("MANAGER 가 삭제 시도 → 403 (DELETE 는 MASTER 전용)")
+    void delete_byManager_403() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/categories/" + category.getId(), token)
+                .andExpect(status().isForbidden());
+
+        // 트랜잭션 내 실제로 삭제되지 않았는지 확인
+        assertThat(categoryRepository.findById(category.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 삭제 시도 → 403")
+    void delete_byCustomer_403() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/categories/" + category.getId(), token)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 상태 DELETE 요청 → 403 (anonymous 에 대한 @PreAuthorize 거부)")
+    void delete_unauthenticated_403() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        mockMvc.perform(delete("/api/v1/categories/" + category.getId()))
+                .andExpect(status().isForbidden());
+
+        assertThat(categoryRepository.findById(category.getId())).isPresent();
+    }
+
+    // ────────────────────────────────────────────────
+    // 사용 중 Store 가드
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("사용 중인 Store 가 있으면 → 409 CATEGORY_IN_USE")
+    void delete_categoryInUse_409() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+        seedStoreOn(category.getId());
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/categories/" + category.getId(), token)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("해당 카테고리를 사용 중인 가게가 있어 삭제할 수 없습니다."));
+
+        // 가드에 의해 실제로 삭제되지 않았어야 함
+        assertThat(categoryRepository.findById(category.getId())).isPresent();
+    }
+
+    // ────────────────────────────────────────────────
+    // 삭제 후 후속 조회 / 재참조
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("삭제 성공 후 단건 조회 → 404")
+    void getAfterDelete_404() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/categories/" + category.getId(), token)
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/categories/{id}", category.getId()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("카테고리를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("Soft-deleted categoryId 로 Store 생성 시도 → 404 CATEGORY_NOT_FOUND")
+    void createStoreWithDeletedCategory_404() throws Exception {
+        // given: 지역(살아있음) + 카테고리(soft-deleted) + OWNER 로그인
+        AreaEntity area = seedArea("광화문", "서울특별시", "종로구", true);
+        CategoryEntity category = seedCategory("한식");
+        category.softDelete("master01");
+        categoryRepository.save(category);
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        String token = login(owner.getUsername().value(), DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 분식", "서울 종로구 어딘가 1", null, 5000);
+
+        // when & then
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("카테고리를 찾을 수 없습니다."));
+    }
+
+    // ────────────────────────────────────────────────
+    // private helpers
+    // ────────────────────────────────────────────────
+
+    private ResultActions authedPost(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private AreaEntity seedArea(String name, String city, String district, boolean isActive) {
+        return areaRepository.save(AreaEntity.builder()
+                .name(name)
+                .city(city)
+                .district(district)
+                .isActive(isActive)
+                .build());
+    }
+
+    private CategoryEntity seedCategory(String name) {
+        return categoryRepository.save(CategoryEntity.builder().
+                name(name)
+                .build());
+    }
+
+    /**
+     * category 사용 중 가드 검증 전용 — Store 도메인의 입력 검증/권한 흐름은 별도 테스트에서 다루므로,
+     * 여기서는 repository 직접 저장으로 store row 만 만든다.
+     * (StoreEntity 는 ownerId/categoryId 에 FK 제약이 없는 단순 UUID 컬럼이므로 임의 값 허용)
+     */
+    private StoreEntity seedStoreOn(UUID categoryId) {
+        return storeRepository.save(StoreEntity.builder()
+                .ownerId(UUID.randomUUID())
+                .categoryId(categoryId)
+                .areaId(UUID.randomUUID())
+                .name("사용중-가게")
+                .address("서울특별시 종로구 어딘가 1")
+                .phone(null)
+                .minOrderAmount(5000)
+                .build());
+    }
+}

--- a/src/test/java/com/example/delivery/store/integration/StoreCrudIntegrationTest.java
+++ b/src/test/java/com/example/delivery/store/integration/StoreCrudIntegrationTest.java
@@ -1,0 +1,725 @@
+package com.example.delivery.store.integration;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import com.example.delivery.store.presentation.dto.request.ReqCreateStoreDto;
+import com.example.delivery.store.presentation.dto.request.ReqUpdateStoreDto;
+import com.example.delivery.user.domain.entity.UserEntity;
+import com.example.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Store CRUD 통합 테스트 — 권한 매트릭스 + Validation + 연관 엔티티(Category/Area) 검증 +
+ * DB 영속 + 예외 핸들러까지의 흐름 검증.
+ *
+ * 본 클래스는 POST(생성) / PATCH(정보 수정) / DELETE 흐름만 다룬다.
+ * - 단건 조회 숨김 분기 / 숨김 토글 → {@code StoreVisibilityIntegrationTest}
+ * - 목록 조회 / 정렬 / 페이지 사이즈 화이트리스트 → {@code StoreSearchIntegrationTest}
+ *
+ * 정책 메모
+ * - SecurityConfig 에서 /api/v1/stores/** 는 anyRequest().permitAll() 에 해당하지만,
+ *   변경 계열 엔드포인트는 컨트롤러의 @PreAuthorize 로 권한이 강제된다.
+ *   따라서 미인증 POST/PATCH/DELETE 의 응답은 ExceptionTranslationFilter 가 아니라
+ *   GlobalExceptionHandler.handleAccessDenied 를 통한 403 으로 정규화된다.
+ *   (UserAuthSmokeIntegrationTest 의 401 흐름과 다른 점에 주의)
+ *
+ * - 가게 생성(POST) 권한       : OWNER 전용
+ *   가게 정보 수정(PATCH)       : OWNER(본인) / MANAGER / MASTER
+ *   가게 삭제(DELETE)           : OWNER(본인) / MASTER  (MANAGER 불가)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class StoreCrudIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    AreaRepository areaRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    StoreRepository storeRepository;
+
+    // ────────────────────────────────────────────────
+    // POST /api/v1/stores
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("OWNER 가 가게 생성 → 201 + DB 반영 + createdBy 설정")
+    void create_byOwner_201() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", "02-1234-5678", 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.name").value("광화문 한식당"))
+                .andExpect(jsonPath("$.data.ownerId").value(owner.getId().toString()))
+                .andExpect(jsonPath("$.data.categoryId").value(category.getId().toString()))
+                .andExpect(jsonPath("$.data.areaId").value(area.getId().toString()))
+                .andExpect(jsonPath("$.data.minOrderAmount").value(15000))
+                .andExpect(jsonPath("$.data.isHidden").value(false))
+                .andExpect(jsonPath("$.data.createdBy").value("ownr01"));
+
+        StoreEntity persisted = storeRepository
+                .findByOwnerIdAndName(owner.getId(), "광화문 한식당").orElseThrow();
+        assertThat(persisted.getOwnerId()).isEqualTo(owner.getId());
+        assertThat(persisted.getCreatedBy()).isEqualTo("ownr01");
+    }
+
+    @Test
+    @DisplayName("MASTER 가 가게 생성 시도 → 403 (POST 는 OWNER 전용)")
+    void create_byMaster_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 가게 생성 시도 → 403")
+    void create_byCustomer_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 상태에서 가게 생성 시도 → 403 (anonymous 에 대한 @PreAuthorize 거부)")
+    void create_unauthenticated_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 15000);
+
+        unauthedPost("/api/v1/stores", body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("동일 OWNER 가 동일 가게명으로 재생성 → 409 STORE_ALREADY_EXISTS")
+    void create_duplicateNameForSameOwner_409() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        seedStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 99", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message")
+                        .value("해당 소유자가 이미 동일한 이름의 가게를 보유하고 있습니다."));
+    }
+
+    @Test
+    @DisplayName("다른 OWNER 가 같은 가게명으로 등록 → 201 (동일 소유자 기준 unique)")
+    void create_sameNameDifferentOwner_201() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity ownerA = seedUser("ownr01", UserRole.OWNER);
+        seedStore(ownerA.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("ownr02", UserRole.OWNER);
+        String tokenB = login("ownr02", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 22", null, 15000);
+
+        authedPost("/api/v1/stores", tokenB, body)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.name").value("광화문 한식당"))
+                .andExpect(jsonPath("$.data.createdBy").value("ownr02"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 categoryId 로 생성 → 404 CATEGORY_NOT_FOUND")
+    void create_categoryNotFound_404() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+
+        seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                UUID.randomUUID(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("카테고리를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 areaId 로 생성 → 404 AREA_NOT_FOUND")
+    void create_areaNotFound_404() throws Exception {
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), UUID.randomUUID(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("지역을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("비활성 area 로 생성 → 400 AREA_INACTIVE")
+    void create_inactiveArea_400() throws Exception {
+        AreaEntity area = seedArea("광화문", false);
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("비활성화된 지역에는 가게를 등록하거나 이전할 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("필수 필드 누락(name 빈 값) → 400 VALIDATION_ERROR + errors[name]")
+    void create_blankName_400() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "   ", "서울 종로구 세종대로 1", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.errors[?(@.field=='name')]").exists());
+    }
+
+    @Test
+    @DisplayName("필수 필드 누락(minOrderAmount null) → 400 VALIDATION_ERROR")
+    void create_nullMinOrderAmount_400() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        // record 직렬화 우회를 위해 raw JSON 사용 (minOrderAmount 키 자체를 누락)
+        String raw = """
+                {
+                  "categoryId":"%s",
+                  "areaId":"%s",
+                  "name":"광화문 한식당",
+                  "address":"서울 종로구 세종대로 1"
+                }
+                """.formatted(category.getId(), area.getId());
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(APPLICATION_JSON)
+                        .content(raw))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.errors[?(@.field=='minOrderAmount')]").exists());
+    }
+
+    @Test
+    @DisplayName("phone 빈 문자열 입력 → 201 + DB 에는 phone null 로 저장")
+    void create_blankPhone_storedAsNull() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", "", 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isCreated());
+
+        StoreEntity persisted = storeRepository
+                .findByOwnerIdAndName(owner.getId(), "광화문 한식당").orElseThrow();
+        assertThat(persisted.getPhone()).isNull();
+    }
+
+    // ────────────────────────────────────────────────
+    // PATCH /api/v1/stores/{storeId} (정보 수정)
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("OWNER 본인이 자신의 가게 수정 → 200 + DB 반영")
+    void update_byOwnerSelf_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당(리뉴얼)", "서울 종로구 세종대로 11", "02-9999-9999", 20000);
+
+        authedPatch("/api/v1/stores/" + store.getId(), token, body)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("광화문 한식당(리뉴얼)"))
+                .andExpect(jsonPath("$.data.minOrderAmount").value(20000));
+
+        StoreEntity reloaded = storeRepository.findById(store.getId()).orElseThrow();
+        assertThat(reloaded.getName()).isEqualTo("광화문 한식당(리뉴얼)");
+        assertThat(reloaded.getAddress()).isEqualTo("서울 종로구 세종대로 11");
+        assertThat(reloaded.getPhone()).isEqualTo("02-9999-9999");
+        assertThat(reloaded.getMinOrderAmount()).isEqualTo(20000);
+    }
+
+    @Test
+    @DisplayName("MANAGER 가 타인 가게 수정 → 200")
+    void update_byManager_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), area.getId(), "원래가게명");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "관리자수정", "서울 종로구 세종대로 1", null, 10000);
+
+        authedPatch("/api/v1/stores/" + store.getId(), token, body)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("관리자수정"));
+    }
+
+    @Test
+    @DisplayName("MASTER 가 타인 가게 수정 → 200")
+    void update_byMaster_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "원래가게명");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "마스터수정", "서울 종로구 세종대로 1", null, 10000);
+
+        authedPatch("/api/v1/stores/" + store.getId(), token, body)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("마스터수정"));
+    }
+
+    @Test
+    @DisplayName("OWNER 가 타인의 가게 수정 시도 → 403 STORE_ACCESS_DENIED")
+    void update_byOtherOwner_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity ownerA = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(ownerA.getId(), category.getId(), area.getId(), "원래가게명");
+
+        seedUser("ownr02", UserRole.OWNER);
+        String tokenB = login("ownr02", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "타인수정시도", "서울 종로구 세종대로 1", null, 10000);
+
+        authedPatch("/api/v1/stores/" + store.getId(), tokenB, body)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("해당 가게에 대한 권한이 없습니다."));
+
+        StoreEntity reloaded = storeRepository.findById(store.getId()).orElseThrow();
+        assertThat(reloaded.getName()).isEqualTo("원래가게명");
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 가게 수정 시도 → 403 (PreAuthorize)")
+    void update_byCustomer_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "수정시도", "서울 종로구 세종대로 1", null, 10000);
+
+        authedPatch("/api/v1/stores/" + store.getId(), token, body)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 상태 PATCH → 403 (anonymous 에 대한 @PreAuthorize 거부)")
+    void update_unauthenticated_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "수정시도", "서울 종로구 세종대로 1", null, 10000);
+
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId())
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 storeId 수정 → 404")
+    void update_storeNotFound_404() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "어떤가게", "서울", null, 10000);
+
+        authedPatch("/api/v1/stores/" + UUID.randomUUID(), token, body)
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("동일 OWNER 의 다른 가게와 동일한 이름으로 수정 → 409")
+    void update_duplicateNameInSameOwner_409() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+
+        seedStore(owner.getId(), category.getId(), area.getId(), "가게A");
+        StoreEntity target = seedStore(owner.getId(), category.getId(), area.getId(), "가게B");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "가게A", "서울", null, 10000);
+
+        authedPatch("/api/v1/stores/" + target.getId(), token, body)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message")
+                        .value("해당 소유자가 이미 동일한 이름의 가게를 보유하고 있습니다."));
+    }
+
+    @Test
+    @DisplayName("같은 이름으로 수정(자기 자신) → 중복 검증 통과 200")
+    void update_sameName_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 999", null, 18000);
+
+        authedPatch("/api/v1/stores/" + store.getId(), token, body)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.address").value("서울 종로구 세종대로 999"))
+                .andExpect(jsonPath("$.data.minOrderAmount").value(18000));
+    }
+
+    @Test
+    @DisplayName("비활성 area 로 수정 → 400 AREA_INACTIVE")
+    void update_inactiveArea_400() throws Exception {
+        AreaEntity activeArea = seedArea("광화문", true);
+        AreaEntity inactiveArea = seedArea("강남역", false);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), activeArea.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        ReqUpdateStoreDto body = new ReqUpdateStoreDto(
+                category.getId(), inactiveArea.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 10000);
+
+        authedPatch("/api/v1/stores/" + store.getId(), token, body)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("비활성화된 지역에는 가게를 등록하거나 이전할 수 없습니다."));
+    }
+
+    // ────────────────────────────────────────────────
+    // DELETE /api/v1/stores/{storeId}
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("OWNER 본인이 자신의 가게 삭제 → 200 + soft delete 반영(deletedAt/deletedBy)")
+    void delete_byOwnerSelf_softDeletes() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/stores/" + store.getId(), token)
+                .andExpect(status().isOk());
+
+        // findById 는 살아있는 row 만 보므로(StoreRepositoryImpl.findByIdAndDeletedAtIsNull) 노출되지 않음
+        assertThat(storeRepository.findById(store.getId())).isEmpty();
+        // 동일 OWNER 기준 살아있는 가게도 더 이상 보이지 않음
+        assertThat(storeRepository.findByOwnerIdAndName(owner.getId(), "광화문 한식당")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("MASTER 가 타인 가게 삭제 → 200")
+    void delete_byMaster_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/stores/" + store.getId(), token)
+                .andExpect(status().isOk());
+
+        assertThat(storeRepository.findById(store.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("MANAGER 가 가게 삭제 시도 → 403 (DELETE 는 OWNER/MASTER 전용)")
+    void delete_byManager_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/stores/" + store.getId(), token)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+
+        // 트랜잭션 내 실제로 삭제되지 않았는지 확인
+        assertThat(storeRepository.findById(store.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("OWNER 가 타인의 가게 삭제 시도 → 403 STORE_ACCESS_DENIED")
+    void delete_byOtherOwner_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity ownerA = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(ownerA.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("ownr02", UserRole.OWNER);
+        String tokenB = login("ownr02", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/stores/" + store.getId(), tokenB)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("해당 가게에 대한 권한이 없습니다."));
+
+        assertThat(storeRepository.findById(store.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 가게 삭제 시도 → 403 (PreAuthorize)")
+    void delete_byCustomer_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/stores/" + store.getId(), token)
+                .andExpect(status().isForbidden());
+
+        assertThat(storeRepository.findById(store.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("미인증 상태 DELETE 요청 → 403 (anonymous 에 대한 @PreAuthorize 거부)")
+    void delete_unauthenticated_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        mockMvc.perform(delete("/api/v1/stores/" + store.getId()))
+                .andExpect(status().isForbidden());
+
+        assertThat(storeRepository.findById(store.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 storeId 삭제 → 404 STORE_NOT_FOUND")
+    void delete_storeNotFound_404() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/stores/" + UUID.randomUUID(), token)
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("삭제 성공 후 단건 조회 → 404")
+    void getAfterDelete_404() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        authedDelete("/api/v1/stores/" + store.getId(), token)
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("삭제 성공 후 동일 OWNER 가 같은 이름으로 재생성 → 201 (중복 검증은 살아있는 row 만)")
+    void recreateAfterDelete_201() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        // given: 기존 가게 삭제
+        authedDelete("/api/v1/stores/" + store.getId(), token)
+                .andExpect(status().isOk());
+
+        // when & then: 동일 OWNER 가 같은 이름으로 재생성 가능
+        ReqCreateStoreDto body = new ReqCreateStoreDto(
+                category.getId(), area.getId(),
+                "광화문 한식당", "서울 종로구 세종대로 1", null, 15000);
+
+        authedPost("/api/v1/stores", token, body)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.name").value("광화문 한식당"))
+                .andExpect(jsonPath("$.data.createdBy").value("ownr01"));
+    }
+
+    // ────────────────────────────────────────────────
+    // private helpers (베이스 미수정 정책에 따라 클래스 로컬)
+    // ────────────────────────────────────────────────
+
+    private ResultActions authedPost(String url, String token, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .header("Authorization", "Bearer " + token)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private ResultActions unauthedPost(String url, Object body) throws Exception {
+        return mockMvc.perform(post(url)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)));
+    }
+
+    private AreaEntity seedArea(String name, boolean isActive) {
+        return areaRepository.save(AreaEntity.builder()
+                .name(name)
+                .city("서울특별시")
+                .district("종로구")
+                .isActive(isActive)
+                .build());
+    }
+
+    private CategoryEntity seedCategory(String name) {
+        return categoryRepository.save(CategoryEntity.builder().name(name).build());
+    }
+
+    private StoreEntity seedStore(UUID ownerId, UUID categoryId, UUID areaId, String name) {
+        return storeRepository.save(StoreEntity.builder()
+                .ownerId(ownerId)
+                .categoryId(categoryId)
+                .areaId(areaId)
+                .name(name)
+                .address("서울특별시 종로구 어딘가 1")
+                .phone(null)
+                .minOrderAmount(15000)
+                .build());
+    }
+}

--- a/src/test/java/com/example/delivery/store/integration/StoreSearchIntegrationTest.java
+++ b/src/test/java/com/example/delivery/store/integration/StoreSearchIntegrationTest.java
@@ -1,0 +1,319 @@
+package com.example.delivery.store.integration;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Store 검색/목록 통합 테스트 — keyword/categoryId/areaId 필터 + 정렬 화이트리스트 +
+ * 페이지 사이즈 화이트리스트 + 숨김/비활성 지역 가게 제외 정책 검증.
+ *
+ * GET /api/v1/stores 의 검색·정렬·페이지네이션 흐름만 다룬다.
+ * - 생성/수정/삭제 → {@code StoreCrudIntegrationTest}
+ * - 단건 조회 숨김 분기 / 숨김 토글 → {@code StoreVisibilityIntegrationTest}
+ *
+ * 정책 메모
+ * - 목록 조회는 SecurityConfig 의 anyRequest().permitAll() 로 익명 허용된다.
+ * - 정렬 화이트리스트(StoreRepositoryCustomImpl.resolvePath): {@code createdAt, updatedAt, name, averageRating}
+ *   화이트리스트 외 필드는 OrderSpecifier 변환 시 silently 드롭되며, 모든 필드가 무효일 경우
+ *   {@code STORE.createdAt.desc()} 로 fallback 된다.
+ * - 페이지 사이즈 화이트리스트(PageSizePolicy): {@code 10, 30, 50} 만 통과되며 그 외는 10 으로 보정된다.
+ * - 검색 결과는 항상 살아있는 row 만 본다(STORE.deletedAt.isNull()) + 숨김 가게 제외(STORE.isHidden.isFalse())
+ *   + 비활성 지역의 가게 제외(AREA.isActive.isTrue()).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class StoreSearchIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    AreaRepository areaRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    StoreRepository storeRepository;
+
+    // ────────────────────────────────────────────────
+    // 필터 (keyword / categoryId / areaId)
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("키워드(가게명 부분일치) 필터 → 매칭 항목만 반환")
+    void getAll_keywordFilter() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedStore(category.getId(), area.getId(), "광화문 한식당");
+        seedStore(category.getId(), area.getId(), "광화문 분식당");
+        seedStore(category.getId(), area.getId(), "강남 한식당");
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("keyword", "광화문")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.content[?(@.name=='광화문 한식당')]").exists())
+                .andExpect(jsonPath("$.data.content[?(@.name=='광화문 분식당')]").exists());
+    }
+
+    @Test
+    @DisplayName("categoryId 필터 → 해당 카테고리 가게만 반환")
+    void getAll_categoryFilter() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity korean = seedCategory("한식");
+        CategoryEntity chinese = seedCategory("중식");
+
+        seedStore(korean.getId(), area.getId(), "한식가게A");
+        seedStore(korean.getId(), area.getId(), "한식가게B");
+        seedStore(chinese.getId(), area.getId(), "중식가게");
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("categoryId", korean.getId().toString())
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("areaId 필터 → 해당 지역 가게만 반환")
+    void getAll_areaFilter() throws Exception {
+        AreaEntity gwanghwa = seedArea("광화문", true);
+        AreaEntity gangnam = seedArea("강남역", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedStore(category.getId(), gwanghwa.getId(), "광화문가게A");
+        seedStore(category.getId(), gangnam.getId(), "강남가게A");
+        seedStore(category.getId(), gangnam.getId(), "강남가게B");
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("areaId", gangnam.getId().toString())
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("키워드 + 카테고리 + 지역 합성 필터 → 모든 조건 만족하는 1건만 반환")
+    void getAll_compositeFilter() throws Exception {
+        AreaEntity gwanghwa = seedArea("광화문", true);
+        AreaEntity gangnam = seedArea("강남역", true);
+        CategoryEntity korean = seedCategory("한식");
+        CategoryEntity chinese = seedCategory("중식");
+
+        seedStore(korean.getId(), gwanghwa.getId(), "광화문 한식당");
+        seedStore(chinese.getId(), gwanghwa.getId(), "광화문 중식당");
+        seedStore(korean.getId(), gangnam.getId(), "강남 한식당");
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("keyword", "광화문")
+                        .param("categoryId", korean.getId().toString())
+                        .param("areaId", gwanghwa.getId().toString())
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].name").value("광화문 한식당"));
+    }
+
+    @Test
+    @DisplayName("필터 없이 조회 + 숨김 가게 / 비활성 지역의 가게는 제외")
+    void getAll_excludesHiddenAndInactiveAreaStores() throws Exception {
+        AreaEntity activeArea = seedArea("광화문", true);
+        AreaEntity inactiveArea = seedArea("강남역", false);
+        CategoryEntity category = seedCategory("한식");
+
+        seedStore(category.getId(), activeArea.getId(), "노출가게");
+        seedHiddenStore(category.getId(), activeArea.getId(), "숨김가게");
+        seedStore(category.getId(), inactiveArea.getId(), "비활성지역가게");
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].name").value("노출가게"));
+    }
+
+    // ────────────────────────────────────────────────
+    // 페이지 사이즈 화이트리스트 (10 / 30 / 50)
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("페이지 사이즈 화이트리스트 10/30/50 → 그대로 통과")
+    void getAll_allowedPageSizes_passThrough() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        seedStore(category.getId(), area.getId(), "가게");
+
+        for (int size : new int[]{10, 30, 50}) {
+            mockMvc.perform(get("/api/v1/stores")
+                            .param("page", "0")
+                            .param("size", String.valueOf(size)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.size").value(size));
+        }
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 page size(7) → 10 으로 보정")
+    void getAll_invalidSize_normalizedToTen() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        seedStore(category.getId(), area.getId(), "가게");
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("page", "0")
+                        .param("size", "7"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.size").value(10));
+    }
+
+    // ────────────────────────────────────────────────
+    // 정렬 화이트리스트 (createdAt / updatedAt / name / averageRating)
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("정렬 화이트리스트: averageRating,desc 통과 → 평균 평점 내림차순")
+    void getAll_sortByAverageRatingDesc() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedStoreWithRating(category.getId(), area.getId(), "고평점가게", 5);
+        seedStoreWithRating(category.getId(), area.getId(), "중평점가게", 3);
+        seedStoreWithRating(category.getId(), area.getId(), "저평점가게", 1);
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("sort", "averageRating,desc")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(3))
+                .andExpect(jsonPath("$.data.content[0].name").value("고평점가게"))
+                .andExpect(jsonPath("$.data.content[1].name").value("중평점가게"))
+                .andExpect(jsonPath("$.data.content[2].name").value("저평점가게"));
+    }
+
+    @Test
+    @DisplayName("정렬 화이트리스트: averageRating,asc 통과 → 평균 평점 오름차순")
+    void getAll_sortByAverageRatingAsc() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedStoreWithRating(category.getId(), area.getId(), "고평점가게", 5);
+        seedStoreWithRating(category.getId(), area.getId(), "저평점가게", 1);
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("sort", "averageRating,asc")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].name").value("저평점가게"))
+                .andExpect(jsonPath("$.data.content[1].name").value("고평점가게"));
+    }
+
+    @Test
+    @DisplayName("정렬 비허용 필드는 무시되고 화이트리스트 필드만 적용")
+    void getAll_mixedSortFields_dropsInvalidKeepsValid() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+
+        seedStoreWithRating(category.getId(), area.getId(), "고평점가게", 5);
+        seedStoreWithRating(category.getId(), area.getId(), "저평점가게", 1);
+
+        // garbageField 는 화이트리스트에 없어 무시되고, averageRating,desc 만 적용된다
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("sort", "garbageField,desc")
+                        .param("sort", "averageRating,desc")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.content[0].name").value("고평점가게"))
+                .andExpect(jsonPath("$.data.content[1].name").value("저평점가게"));
+    }
+
+    @Test
+    @DisplayName("정렬: 비허용 필드만 입력 → 오류 없이 fallback 동작(200, 누락 없음)")
+    void getAll_onlyInvalidSortField_fallbackOk() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        seedStore(category.getId(), area.getId(), "가게A");
+        seedStore(category.getId(), area.getId(), "가게B");
+
+        // 모든 sort 필드가 화이트리스트 미포함 → STORE.createdAt.desc() 로 fallback
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("sort", "garbageField,desc")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+    // ────────────────────────────────────────────────
+    // private helpers (베이스 미수정 정책에 따라 클래스 로컬)
+    // ────────────────────────────────────────────────
+
+    private AreaEntity seedArea(String name, boolean isActive) {
+        return areaRepository.save(AreaEntity.builder()
+                .name(name)
+                .city("서울특별시")
+                .district("종로구")
+                .isActive(isActive)
+                .build());
+    }
+
+    private CategoryEntity seedCategory(String name) {
+        return categoryRepository.save(CategoryEntity.builder().name(name).build());
+    }
+
+    private StoreEntity seedStore(UUID categoryId, UUID areaId, String name) {
+        return storeRepository.save(StoreEntity.builder()
+                .ownerId(UUID.randomUUID())
+                .categoryId(categoryId)
+                .areaId(areaId)
+                .name(name)
+                .address("서울특별시 종로구 어딘가 1")
+                .phone(null)
+                .minOrderAmount(15000)
+                .build());
+    }
+
+    private StoreEntity seedHiddenStore(UUID categoryId, UUID areaId, String name) {
+        StoreEntity store = seedStore(categoryId, areaId, name);
+        store.toggleHidden(); // false → true
+        return storeRepository.save(store);
+    }
+
+    /**
+     * averageRating 정렬 검증 전용 — 가게 생성 후 ratings 리스트로 평균 평점을 세팅한다.
+     * StoreEntity.recalculateAverageRating(...) 은 평균을 0.0 ~ 5.0 범위로 강제하므로
+     * 단일 정수 rating(1~5)을 그대로 평균값으로 사용한다.
+     */
+    private StoreEntity seedStoreWithRating(UUID categoryId, UUID areaId, String name, int rating) {
+        StoreEntity store = seedStore(categoryId, areaId, name);
+        store.recalculateAverageRating(List.of(rating));
+        return storeRepository.save(store);
+    }
+}

--- a/src/test/java/com/example/delivery/store/integration/StoreVisibilityIntegrationTest.java
+++ b/src/test/java/com/example/delivery/store/integration/StoreVisibilityIntegrationTest.java
@@ -1,0 +1,357 @@
+package com.example.delivery.store.integration;
+
+import com.example.delivery.area.domain.entity.AreaEntity;
+import com.example.delivery.area.domain.repository.AreaRepository;
+import com.example.delivery.category.domain.entity.CategoryEntity;
+import com.example.delivery.category.domain.repository.CategoryRepository;
+import com.example.delivery.global.test.IntegrationTestSupport;
+import com.example.delivery.store.domain.entity.StoreEntity;
+import com.example.delivery.store.domain.repository.StoreRepository;
+import com.example.delivery.user.domain.entity.UserEntity;
+import com.example.delivery.user.domain.entity.UserRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Store Visibility 통합 테스트 — 단건 조회의 숨김 분기 + 숨김 토글 흐름 검증.
+ *
+ * GET /api/v1/stores/{id} 의 숨김 정책 + PATCH /api/v1/stores/{id}/hide 의 권한 매트릭스를 다룬다.
+ * - 생성/수정/삭제 → {@code StoreCrudIntegrationTest}
+ * - 목록/검색/정렬/페이지 사이즈 → {@code StoreSearchIntegrationTest}
+ *
+ * 정책 메모
+ * - GET 단건은 SecurityConfig 의 anyRequest().permitAll() 로 익명 허용된다.
+ *   다만 서비스 계층이 isHidden=true 인 가게에 한해 OWNER/MANAGER/MASTER 가 아니면
+ *   StoreNotFoundException 으로 정규화하여 404 로 응답한다(정보 노출 회피).
+ *
+ * - PATCH /hide 는 컨트롤러의 @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')") 로 권한이 강제되며
+ *   서비스 계층의 assertModifiable 이 OWNER 본인 / MANAGER / MASTER 만 통과시킨다(타 OWNER 차단).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class StoreVisibilityIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    AreaRepository areaRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    StoreRepository storeRepository;
+
+    // ────────────────────────────────────────────────
+    // GET /api/v1/stores/{storeId} - 기본 단건 조회
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("미인증 상태에서도 가게 단건 조회 가능(권한 없음) → 200")
+    void getOne_unauthenticated_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("광화문 한식당"))
+                .andExpect(jsonPath("$.data.storeId").value(store.getId().toString()))
+                .andExpect(jsonPath("$.data.isHidden").value(false));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 storeId 단건 조회 → 404 STORE_NOT_FOUND")
+    void getOne_notFound_404() throws Exception {
+        mockMvc.perform(get("/api/v1/stores/{id}", UUID.randomUUID()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("soft-deleted 가게 단건 조회 → 404 (살아있는 row 만 노출)")
+    void getOne_softDeletedStore_404() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+        store.softDelete("master01");
+        storeRepository.save(store);
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게를 찾을 수 없습니다."));
+    }
+
+    // ────────────────────────────────────────────────
+    // GET /api/v1/stores/{storeId} - 숨김(hidden) 분기
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("숨김 가게는 미인증 사용자에게 미존재로 노출 → 404")
+    void getOne_hiddenStore_unauthenticated_404() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedHiddenStore(
+                UUID.randomUUID(), category.getId(), area.getId(), "비밀가게");
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("숨김 가게는 CUSTOMER 에게도 미존재로 노출 → 404")
+    void getOne_hiddenStore_customer_404() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedHiddenStore(
+                UUID.randomUUID(), category.getId(), area.getId(), "비밀가게");
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("숨김 가게는 본인 OWNER 가 그대로 조회 가능 → 200")
+    void getOne_hiddenStore_byOwnerSelf_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedHiddenStore(
+                owner.getId(), category.getId(), area.getId(), "비밀가게");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("비밀가게"))
+                .andExpect(jsonPath("$.data.isHidden").value(true));
+    }
+
+    @Test
+    @DisplayName("숨김 가게도 MANAGER 는 그대로 조회 가능 → 200")
+    void getOne_hiddenStore_byManager_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedHiddenStore(
+                UUID.randomUUID(), category.getId(), area.getId(), "비밀가게");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("비밀가게"))
+                .andExpect(jsonPath("$.data.isHidden").value(true));
+    }
+
+    @Test
+    @DisplayName("숨김 가게도 MASTER 는 그대로 조회 가능 → 200")
+    void getOne_hiddenStore_byMaster_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedHiddenStore(
+                UUID.randomUUID(), category.getId(), area.getId(), "비밀가게");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("비밀가게"))
+                .andExpect(jsonPath("$.data.isHidden").value(true));
+    }
+
+    // ────────────────────────────────────────────────
+    // PATCH /api/v1/stores/{storeId}/hide - 숨김 토글
+    // ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("OWNER 본인이 자신의 가게 숨김 토글 → 200 + isHidden=true + 후속 GET 반영")
+    void toggleHidden_byOwnerSelf_thenGetReflects() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        // 토글: false → true
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId() + "/hide")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isHidden").value(true));
+
+        // 본인 OWNER 의 후속 GET 은 isHidden=true 를 그대로 노출
+        mockMvc.perform(get("/api/v1/stores/{id}", store.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isHidden").value(true));
+
+        StoreEntity reloaded = storeRepository.findById(store.getId()).orElseThrow();
+        assertThat(reloaded.isHidden()).isTrue();
+    }
+
+    @Test
+    @DisplayName("숨김 가게를 다시 토글 → 200 + isHidden=false (복원)")
+    void toggleHidden_twice_returnsToFalse() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity owner = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedHiddenStore(owner.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        String token = login("ownr01", DEFAULT_PASSWORD);
+
+        // 한 번 더 토글: true → false
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId() + "/hide")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isHidden").value(false));
+
+        StoreEntity reloaded = storeRepository.findById(store.getId()).orElseThrow();
+        assertThat(reloaded.isHidden()).isFalse();
+    }
+
+    @Test
+    @DisplayName("MANAGER 가 타인 가게 숨김 토글 → 200")
+    void toggleHidden_byManager_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("manager01", UserRole.MANAGER);
+        String token = login("manager01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId() + "/hide")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isHidden").value(true));
+    }
+
+    @Test
+    @DisplayName("MASTER 가 타인 가게 숨김 토글 → 200")
+    void toggleHidden_byMaster_200() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId() + "/hide")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isHidden").value(true));
+    }
+
+    @Test
+    @DisplayName("OWNER 가 타인 가게 숨김 토글 → 403 STORE_ACCESS_DENIED")
+    void toggleHidden_byOtherOwner_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        UserEntity ownerA = seedUser("ownr01", UserRole.OWNER);
+        StoreEntity store = seedStore(ownerA.getId(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("ownr02", UserRole.OWNER);
+        String tokenB = login("ownr02", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId() + "/hide")
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("해당 가게에 대한 권한이 없습니다."));
+
+        StoreEntity reloaded = storeRepository.findById(store.getId()).orElseThrow();
+        assertThat(reloaded.isHidden()).isFalse();
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 가 숨김 토글 시도 → 403 (PreAuthorize)")
+    void toggleHidden_byCustomer_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        seedUser("cust01", UserRole.CUSTOMER);
+        String token = login("cust01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId() + "/hide")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("미인증 상태 숨김 토글 → 403")
+    void toggleHidden_unauthenticated_403() throws Exception {
+        AreaEntity area = seedArea("광화문", true);
+        CategoryEntity category = seedCategory("한식");
+        StoreEntity store = seedStore(UUID.randomUUID(), category.getId(), area.getId(), "광화문 한식당");
+
+        mockMvc.perform(patch("/api/v1/stores/" + store.getId() + "/hide"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 storeId 숨김 토글 → 404")
+    void toggleHidden_storeNotFound_404() throws Exception {
+        seedUser("master01", UserRole.MASTER);
+        String token = login("master01", DEFAULT_PASSWORD);
+
+        mockMvc.perform(patch("/api/v1/stores/" + UUID.randomUUID() + "/hide")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게를 찾을 수 없습니다."));
+    }
+
+    // ────────────────────────────────────────────────
+    // private helpers (베이스 미수정 정책에 따라 클래스 로컬)
+    // ────────────────────────────────────────────────
+
+    private AreaEntity seedArea(String name, boolean isActive) {
+        return areaRepository.save(AreaEntity.builder()
+                .name(name)
+                .city("서울특별시")
+                .district("종로구")
+                .isActive(isActive)
+                .build());
+    }
+
+    private CategoryEntity seedCategory(String name) {
+        return categoryRepository.save(CategoryEntity.builder().name(name).build());
+    }
+
+    private StoreEntity seedStore(UUID ownerId, UUID categoryId, UUID areaId, String name) {
+        return storeRepository.save(StoreEntity.builder()
+                .ownerId(ownerId)
+                .categoryId(categoryId)
+                .areaId(areaId)
+                .name(name)
+                .address("서울특별시 종로구 어딘가 1")
+                .phone(null)
+                .minOrderAmount(15000)
+                .build());
+    }
+
+    private StoreEntity seedHiddenStore(UUID ownerId, UUID categoryId, UUID areaId, String name) {
+        StoreEntity store = seedStore(ownerId, categoryId, areaId, name);
+        store.toggleHidden(); // false → true
+        return storeRepository.save(store);
+    }
+}


### PR DESCRIPTION
## 관련이슈

close #71 


## 도메인별 시나리오 매핑

### Area (`AreaCrudIntegrationTest` + `AreaDeleteGuardIntegrationTest`)

| 시나리오 | 케이스 |
|---|---|
| 생성 권한 매트릭스 | MANAGER/MASTER 201, OWNER·CUSTOMER·미인증 403 |
| 생성 예외 | 이름 중복 409, soft-deleted 이름 재생성 400, validation(name 빈값/isActive null) 400 |
| 단건/목록 조회 | 익명 200, 없는 ID 404, 키워드 부분일치 + 페이지네이션, page size 7 → 10 보정 |
| 수정 | MANAGER 200, CUSTOMER 403, 다른 area 와 중복명 409, 자기 자신 같은 이름 200, 없는 ID 404 |
| 삭제 권한 매트릭스 | MASTER 200(soft delete), MANAGER/CUSTOMER/미인증 403 |
| **삭제 가드** | 사용 중인 Store 가 있으면 409 `AREA_IN_USE` |
| 삭제 후 흐름 | 후속 단건 조회 404, soft-deleted areaId 로 Store 생성 시도 → 404 `AREA_NOT_FOUND` |

### Category (`CategoryCrudIntegrationTest` + `CategoryDeleteGuardIntegrationTest`)

| 시나리오 | 케이스 |
|---|---|
| 생성 권한 매트릭스 | MANAGER/MASTER 201, OWNER·CUSTOMER·미인증 403 |
| 생성 예외 | 이름 중복 409, soft-deleted 이름 재생성 400, validation(name 빈값) 400 |
| 단건/목록 조회 | 익명 200, 없는 ID 404, 키워드 부분일치 + 페이지네이션, page size 7 → 10 보정 |
| 수정 | MANAGER 200, CUSTOMER 403, 다른 카테고리와 중복명 409, 자기 자신 같은 이름 200, 없는 ID 404 |
| 삭제 권한 매트릭스 | MASTER 200(soft delete), MANAGER/CUSTOMER/미인증 403 |
| **삭제 가드** | 사용 중인 Store 가 있으면 409 `CATEGORY_IN_USE` |
| 삭제 후 흐름 | 후속 단건 조회 404, soft-deleted categoryId 로 Store 생성 시도 → 404 `CATEGORY_NOT_FOUND` |

### Store

#### `StoreCrudIntegrationTest` — POST / PATCH(수정) / DELETE

| 시나리오 | 케이스 |
|---|---|
| 생성 권한 | OWNER 201, MASTER/CUSTOMER/미인증 403 |
| 생성 예외 | 동일 OWNER 동명 409, 다른 OWNER 동명 201, category/area 404, **비활성 area 400 `AREA_INACTIVE`**, validation(name·minOrderAmount), phone 빈문자열 → null |
| 수정 권한 | OWNER 본인·MANAGER·MASTER 200, 타 OWNER 403 `STORE_ACCESS_DENIED`, CUSTOMER·미인증 403 |
| 수정 예외 | storeId 404, 동일 OWNER 내 중복명 409, 자기 자신 같은 이름 200, 비활성 area 로 이전 400 |
| 삭제 권한 | OWNER 본인·MASTER 200, **MANAGER 403** (DELETE 는 OWNER/MASTER 전용), 타 OWNER·CUSTOMER·미인증 403 |
| 삭제 후 흐름 | storeId 404, 후속 GET 404, **동일 OWNER 가 같은 이름으로 재생성 → 201** (중복 검증은 살아있는 row 만) |

#### `StoreVisibilityIntegrationTest` — GET 단건 숨김 분기 + PATCH 숨김 토글

| 시나리오 | 케이스 |
|---|---|
| 단건 조회 기본 | 미인증 200, 없음 404, soft-deleted 404 |
| **숨김 분기** | 미인증·CUSTOMER 404 (정보 노출 회피), 본인 OWNER·MANAGER·MASTER 200 |
| 숨김 토글 권한 | OWNER 본인·MANAGER·MASTER 200, 타 OWNER 403, CUSTOMER·미인증 403 |
| 숨김 토글 흐름 | 토글 후 본인 GET 에서 `isHidden=true` 반영 / 다시 토글 → false 복원 / 없는 ID 404 |

#### `StoreSearchIntegrationTest` — GET 목록(검색·정렬·페이지네이션)

| 시나리오 | 케이스 |
|---|---|
| 필터 | keyword(부분일치) / categoryId / areaId / 합성 필터 |
| 노출 정책 | 숨김 가게 + 비활성 지역의 가게는 목록에서 제외 |
| 페이지 사이즈 | 화이트리스트 10/30/50 통과, 그 외(7) → 10 보정 |
| 정렬 화이트리스트 | `averageRating,desc` / `averageRating,asc` 통과, 비허용 필드 무시 + 화이트리스트 필드 유지, 모든 필드 무효 시 fallback 200 |

## 접근 / 트레이드오프


1. **변경 계열 엔드포인트의 미인증 응답 = 403 (401 아님)**
   - SecurityConfig 에서 `/api/v1/areas|categories|stores/**` 는 `anyRequest().permitAll()` 로 통과되고, 변경 계열은 컨트롤러의 `@PreAuthorize` 로 강제됩니다. 따라서 미인증 POST/PATCH/DELETE 의 응답은 `ExceptionTranslationFilter` 가 아니라 `GlobalExceptionHandler.handleAccessDenied` 를 통한 **403** 으로 정규화됩니다. (`UserAuthSmokeIntegrationTest` 의 401 흐름과 다른 점에 주의 — 본 PR 의 모든 미인증 케이스 주석에 명시했습니다.)


2. **POST 응답코드 200 → 201 정정**
   - 통합 테스트로 명세(`@ApiResponse(responseCode = "201")`) 와 실제 응답을 처음 대조하면서 발견한 불일치입니다. 별도 fix 커밋(`fix: ...`) 으로 분리해 PR 안에서 변경 의도가 보이도록 했습니다.